### PR TITLE
Reload workflow

### DIFF
--- a/doc/src/ornate.conf
+++ b/doc/src/ornate.conf
@@ -5,7 +5,6 @@ global {
     getting-started.md
     cookbook.md
     reference.md
-    issues.md
   ]
 }
 
@@ -13,4 +12,4 @@ meta {
   siteTitle = "scalajs-bundler"
 }
 
-version = "0.1"
+version = "0.2"

--- a/doc/src/site/cookbook.md
+++ b/doc/src/site/cookbook.md
@@ -73,11 +73,3 @@ has to include the `sbt-scalajs-bundler` plugin.
 > {.warning}
 > If the project that uses the facade does not include the `sbt-scalajs-bundler` plugin, the npm dependencies
 > of the facade will not be resolved.
-
-## How to improve the performance of the bundling process? {#performance}
-
-As reported [here](https://github.com/scalacenter/scalajs-bundler/issues/1#issuecomment-254153548),
-webpack might have pain to bundle your application, if this one is big (the `fastOptJS` output of
-a 5k SLOC application can weigh more than 4MB). To our knowledge,
-the fastest configuration is to bundle the output of `fastOptJS` with
-[disabled source maps](reference.md).

--- a/doc/src/site/index.md
+++ b/doc/src/site/index.md
@@ -7,5 +7,5 @@ scalajs-bundler uses [npm](https://www.npmjs.com) and [webpack](https://webpack.
 
 Last stable version is ![](config:version).
 
-[Get started](getting-started.md) now, [contribute](https://github.com/scalacenter/scalajs-bundler), or [get
+[**Get started**](getting-started.md), [contribute](https://github.com/scalacenter/scalajs-bundler), or [get
 in touch](https://gitter.im/scalacenter/scalajs-bundler)!

--- a/doc/src/site/issues.md
+++ b/doc/src/site/issues.md
@@ -1,9 +1,0 @@
-# Known issues
-
-## Bundling time
-
-Bundling time for large applications can be long. See the numbers
-[here](https://github.com/scalacenter/scalajs-bundler/issues/1#issuecomment-254153548).
-
-We are working on solutions to this problem. In the meanwhile, you can
-follow [this advice](cookbook.md#performance).

--- a/doc/src/site/reference.md
+++ b/doc/src/site/reference.md
@@ -44,6 +44,12 @@ You can use [semver](https://docs.npmjs.com/misc/semver) versions.
 
 `npmDevDependencies`: list of the NPM packages (name and version) your build depends on.
 
+`enableReloadWorkflow`: whether to enable the “reload workflow” for `webpack in fastOptJS`.
+When enabled, dependencies are pre-bundled so that the output of `fastOptJS` can directly
+be executed by a web browser without being further processed by a bundling system. This
+reduces the delays when live-reloading the application on source modifications. Defaults
+to `true`.
+
 `webpackEntries`: list of entry bundles to generate. By default it generates just one bundle
 for your main class.
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Commands.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Commands.scala
@@ -24,9 +24,9 @@ object Commands {
     run("npm run bundle", cwd, log)
   }
 
-  def run(cmd: String, cwd: File, logger: Logger): Unit = {
+  def run(cmd: String, cwd: File, errorLogger: Logger): Unit = {
     val process = Process(cmd, cwd)
-    process !! logger // FIXME Also redirect the standard output of the process to the logger
+    process !! errorLogger // FIXME Also redirect the standard output of the process to the logger
     ()
   }
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ConfigFiles.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ConfigFiles.scala
@@ -81,7 +81,7 @@ object ConfigFiles {
           if (currentConfiguration == Compile) npmManifestDependencies.compileDevDependencies
           else npmManifestDependencies.testDevDependencies
         ) ++ (
-          if (emitSourceMaps) npmDevDependencies :+ ("source-map-loader" -> "0.1.5")
+          if (emitSourceMaps) npmDevDependencies ++ Seq("source-map-loader" -> "0.1.5", "concat-with-sourcemaps" -> "1.0.4")
           else npmDevDependencies
         )
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/JS.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/JS.scala
@@ -14,6 +14,9 @@ object JS {
   def str(value: String): StringLiteral =
     StringLiteral(value)
 
+  /** Boolean literal */
+  def bool(value: Boolean): BooleanLiteral = BooleanLiteral(value)
+
   /** Object literal */
   def obj(fields: (String, Tree)*): ObjectConstr =
     ObjectConstr(fields.map { case (ident, value) => (str(ident), value) }.to[List])
@@ -40,6 +43,25 @@ object JS {
     val param = freshIdentifier()
     Function(List(ParamDef(Ident(param), rest = false)), Return(body(ref(param))))
   }
+
+  /** Name binding */
+  def let(value: Tree)(usage: VarRef => Tree): Tree = {
+    val ident = freshIdentifier()
+    Block(VarDef(Ident(ident), value), usage(ref(ident)))
+  }
+
+  /** Name binding */
+  def let(value1: Tree, value2: Tree)(usage: (VarRef, VarRef) => Tree): Tree = {
+    val ident1 = freshIdentifier()
+    val ident2 = freshIdentifier()
+    Block(
+      VarDef(Ident(ident1), value1),
+      VarDef(Ident(ident2), value2),
+      usage(ref(ident1), ref(ident2))
+    )
+  }
+
+  def `new`(ctor: Tree, args: Tree*): New = New(ctor, args.to[List])
 
   def toJson(obj: ObjectConstr): String = show(obj, isStat = false)
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Launcher.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Launcher.scala
@@ -26,16 +26,25 @@ object Launcher {
 
     val launcherContent = {
       val module = JS.ref("require")(JS.str(sjsStageOutput.absolutePath))
-      val mainClassRef =
-        mainClass
-          .split('.')
-          .foldLeft[Trees.Tree](module) { (tree, part) => tree.bracket(part) }
-      (mainClassRef() `.` "main")()
+      callEntryPoint(mainClass, module)
     }
     val launcherFile = targetDir / "launcher.js" // TODO Use different names according to the sjsStages
     IO.write(launcherFile, launcherContent.show)
 
     Launcher(launcherFile, mainClass)
+  }
+
+  /**
+    * @param mainClass Main class name
+    * @param module Module exporting the entry point
+    * @return A JavaScript program that calls the main method of the main class
+    */
+  def callEntryPoint(mainClass: String, module: Trees.Tree): Trees.Tree = {
+    val mainClassRef =
+      mainClass
+        .split('.')
+        .foldLeft[Trees.Tree](module)((tree, part) => tree.bracket(part))
+    (mainClassRef() `.` "main")()
   }
 
 }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
@@ -1,0 +1,142 @@
+package scalajsbundler
+
+import org.scalajs.core.ir.Trees.JSNativeLoadSpec
+import org.scalajs.core.tools.io.VirtualScalaJSIRFile
+import org.scalajs.core.tools.linker.ClearableLinker
+import org.scalajs.core.tools.linker.backend.{BasicLinkerBackend, LinkerBackend, OutputMode}
+import org.scalajs.sbtplugin.Loggers
+import org.scalajs.sbtplugin.ScalaJSPlugin.AutoImport._
+import sbt._
+
+import JS.syntax._
+
+/**
+  * Faster workflow when a developer changes the source code and then reloads the application.
+  *
+  * It pre-bundles the dependencies once and then recompiles just the part of the application
+  * that changed.
+  *
+  * For this to work, the pre-bundled dependencies are exposed to the global namespace and a fake `require`
+  * implementation is also provided so that the output of Scala.js, which is supposed to be executed by
+  * a CommonJS compatible environment, can be executed by a web browser.
+  */
+object ReloadWorkflow {
+
+  /**
+    * @return A file that contains the concatenation of the dependencies bundle and the output of the Scala.js compilation
+    * @param bundledDependencies Pre-bundled dependencies
+    * @param loaderAndLauncher `require` implementation and entry point launcher
+    * @param sjsOutput Output of Scala.js
+    * @param targetDir Target directory (where to write the bundle)
+    */
+  def writeFakeBundle(
+    bundledDependencies: File,
+    loaderAndLauncher: LoaderAndLauncher,
+    sjsOutput: File,
+    targetDir: File
+  ): File = {
+    val moduleName = sjsOutput.name.stripSuffix(".js")
+    val bundle = targetDir / s"$moduleName-bundle.js" // Because scalajs.webpack.config.js defines the output as "[name]-bundle.js"
+    IO.copyFile(bundledDependencies, bundle)
+    IO.append(bundle, "\n")
+    IO.append(bundle, IO.readBytes(loaderAndLauncher.loader)) // shims `require`
+    IO.append(bundle, ";\n")
+    IO.append(bundle, IO.readBytes(sjsOutput))
+    IO.append(bundle, "\n")
+    IO.append(bundle, IO.readBytes(loaderAndLauncher.launcher))
+    bundle
+  }
+
+  /**
+    * @return The written loader (faking a `require` implementation) and launcher files
+    * @param mainClass Application entry point
+    * @param targetDir Target directory
+    */
+  def writeLoaderAndLauncher(mainClass: String, targetDir: File): LoaderAndLauncher = {
+    val depsLoader = targetDir / "scalajsbundler-deps-loader.js"
+    val window = JS.ref("window")
+    val depsLoaderContent =
+      JS.block(
+        (window `.` "require") := JS.fun(name => window.bracket((JS.str(modulePrefix) `.` "concat")(name))),
+        (window `.` "exports") := JS.obj()
+      )
+    IO.write(depsLoader, depsLoaderContent.show)
+
+    val launcher = targetDir / "scalajsbundler-launcher.js"
+    val launcherContent = Launcher.callEntryPoint(mainClass, window `.` "exports")
+    IO.write(launcher, launcherContent.show)
+
+    LoaderAndLauncher(depsLoader, launcher)
+  }
+
+  /**
+    * @return The imported dependencies of the Scala.js project, bundled into a single file, and exported to the
+    *         global namespace
+    * @param linker Scala.js linker
+    * @param irFiles Scala.js IR files
+    * @param outputMode Scala.js output mode
+    * @param emitSourceMaps Whether emitSourceMaps is enabled
+    * @param targetDir Target directory (also the directory where we expect node_modules to be present)
+    * @param logger Logger
+    */
+  def bundleDependencies(
+    linker: ClearableLinker,
+    irFiles: Seq[VirtualScalaJSIRFile],
+    outputMode: OutputMode,
+    emitSourceMaps: Boolean,
+    targetDir: File,
+    logger: Logger
+  ): File = {
+    val imports = findImportedModules(linker, irFiles, outputMode, emitSourceMaps, logger)
+    val depsFileContent =
+      JS.block(
+        imports.map { moduleName =>
+          JS.ref("global").bracket(s"$modulePrefix$moduleName") := JS.ref("require")(JS.str(moduleName))
+        }: _*
+      )
+    val dependenciesCjsFile = targetDir / "scalajsbundler-deps-cjs.js"
+    IO.write(dependenciesCjsFile, depsFileContent.show)
+
+    val dependenciesFile = targetDir / "scalajsbundler-deps.js"
+    val webpackBin = targetDir / "node_modules" / "webpack" / "bin" / "webpack"
+    Commands.run(
+      s"node ${webpackBin.absolutePath} ${dependenciesCjsFile.absolutePath} ${dependenciesFile.absolutePath}",
+      targetDir,
+      logger
+    )
+
+    dependenciesFile
+  }
+
+  /**
+    * @return The list of ES modules imported by a Scala.js project
+    * @param linker Scala.js linker
+    * @param irFiles Scala.js IR files
+    * @param outputMode Scala.js output mode
+    * @param emitSourceMaps Whether emitSourceMaps is enabled
+    * @param logger Logger
+    */
+  def findImportedModules(
+    linker: ClearableLinker,
+    irFiles: Seq[VirtualScalaJSIRFile],
+    outputMode: OutputMode,
+    emitSourceMaps: Boolean,
+    logger: Logger
+  ): List[String] = {
+    val semantics = linker.semantics
+    val symbolRequirements =
+      new BasicLinkerBackend(semantics, outputMode, ModuleKind.CommonJSModule, emitSourceMaps, LinkerBackend.Config())
+        .symbolRequirements
+    val linkingUnit =
+      linker.linkUnit(irFiles, symbolRequirements, Loggers.sbtLogger2ToolsLogger(logger))
+    linkingUnit.classDefs.flatMap(_.jsNativeLoadSpec).collect {
+      case JSNativeLoadSpec.Import(module, _) => module
+    }.distinct
+  }
+
+  // Prefix to use to export/import pre-bundled modules to/from the global namespace
+  val modulePrefix = "__scalajsbundler__"
+
+  case class LoaderAndLauncher(loader: File, launcher: File)
+
+}

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflowTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflowTasks.scala
@@ -11,13 +11,17 @@ object ReloadWorkflowTasks {
 
   def webpackTask(stage: TaskKey[Attributed[File]]): Def.Initialize[Task[Seq[File]]] =
     Def.task {
+      val targetDir = (crossTarget in stage).value
       Seq(
         ReloadWorkflow.writeFakeBundle(
+          (webpackEmitSourceMaps in stage).value,
           bundleDependenciesTask(stage).value,
           writeLoaderTask(stage).value,
           writeLauncherTask(stage).value,
           stage.value.data,
-          (crossTarget in stage).value
+          targetDir,
+          targetDir,
+          streams.value.log
         )
       )
     }
@@ -33,7 +37,7 @@ object ReloadWorkflowTasks {
           ScalaJSPluginInternal.scalaJSLinker.value,
           scalaJSIR.value.data,
           scalaJSOutputMode.value,
-          emitSourceMaps.value,
+          (emitSourceMaps in stage).value,
           logger
         )
       cached(

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflowTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflowTasks.scala
@@ -1,0 +1,47 @@
+package scalajsbundler
+
+import org.scalajs.sbtplugin.ScalaJSPlugin.AutoImport._
+import org.scalajs.sbtplugin.ScalaJSPluginInternal
+import sbt.Keys._
+import sbt._
+import ScalaJSBundlerPlugin.autoImport._
+
+import scalajsbundler.ReloadWorkflow.LoaderAndLauncher
+
+/** Sbt tasks related to the reload workflow */
+object ReloadWorkflowTasks {
+
+  def webpackTask(stage: TaskKey[Attributed[File]]): Def.Initialize[Task[Seq[File]]] =
+    Def.task {
+      Seq(
+        ReloadWorkflow.writeFakeBundle(
+          bundleDependenciesTask(stage).value,
+          writeLoaderAndLauncherTask(stage).value,
+          stage.value.data,
+          (crossTarget in stage).value
+        )
+      )
+    }
+
+  def bundleDependenciesTask(stage: TaskKey[Attributed[File]]): Def.Initialize[Task[File]] =
+    Def.task {
+      ReloadWorkflow.bundleDependencies(
+        ScalaJSPluginInternal.scalaJSLinker.value,
+        scalaJSIR.value.data,
+        scalaJSOutputMode.value,
+        emitSourceMaps.value,
+        (crossTarget in stage).value,
+        streams.value.log
+      )
+    }.dependsOn(npmUpdate in stage)
+
+  def writeLoaderAndLauncherTask(stage: TaskKey[Attributed[File]]): Def.Initialize[Task[LoaderAndLauncher]] =
+    Def.task {
+      ReloadWorkflow.writeLoaderAndLauncher(
+        (mainClass in (scalaJSLauncher in stage)).value.getOrElse("No main class detected"),
+        (crossTarget in stage).value
+      )
+    }
+
+
+}

--- a/sbt-web-scalajs-bundler/src/main/scala/scalajsbundler/WebScalaJSBundlerPlugin.scala
+++ b/sbt-web-scalajs-bundler/src/main/scala/scalajsbundler/WebScalaJSBundlerPlugin.scala
@@ -32,7 +32,7 @@ object WebScalaJSBundlerPlugin extends AutoPlugin {
         val bundles: Seq[(File, String)] =
           projects
             .map { project =>
-              val task = webpack in(project, Compile, sjsStage in project)
+              val task = webpack in (project, Compile, sjsStage in project)
               val clientTarget = crossTarget in (project, sjsStage)
               (task, clientTarget).map((files, target) => files pair relativeTo(target))
             }

--- a/sbt-web-scalajs-bundler/src/main/scala/scalajsbundler/WebScalaJSBundlerPlugin.scala
+++ b/sbt-web-scalajs-bundler/src/main/scala/scalajsbundler/WebScalaJSBundlerPlugin.scala
@@ -39,7 +39,13 @@ object WebScalaJSBundlerPlugin extends AutoPlugin {
             .foldLeft(Def.task(Seq.empty[(File, String)]))((acc, bundleFiles) => Def.task(acc.value ++ bundleFiles.value))
             .value
         val filtered = filterMappings(mappings, (includeFilter in self).value, (excludeFilter in self).value)
-        filtered ++ bundles ++ WebScalaJS.sourcemapScalaFiles(sjsStage).value
+        val bundlesWithSourceMaps =
+          bundles.flatMap { case (file, path) =>
+            val sourceMapFile = file.getParentFile / (file.name ++ ".map")
+            val sourceMapPath = path ++ ".map"
+            Seq(file -> path, sourceMapFile -> sourceMapPath)
+          }
+        filtered ++ bundlesWithSourceMaps ++ WebScalaJS.sourcemapScalaFiles(sjsStage).value
       }
     }
 


### PR DESCRIPTION
This PR implements a faster “reloading workflow”, following an idea submitted by @lihaoyi and @ochrons: the dependencies are pre-bundled together once and then exported to the global namespace. Then, the output of `fastOptJS` can be pasted as it is (without being processed by the module bundler).

As a result, live reloading a project does not anymore involve a real bundling step. In my [control project](https://github.com/scalacenter/scalajs-bundler/issues/1#issuecomment-254153548) I measured a delay of 12 s between the beginning of a recompilation and the time the application is actually reloaded (10 s if source maps are disabled).

Fixes #1.