### PR TITLE
#19 Use distinct working directories for npmUpdate in Compile and npmUpdate in Test

### DIFF
--- a/doc/src/site/reference.md
+++ b/doc/src/site/reference.md
@@ -65,7 +65,9 @@ current configuration, Scala.js stage and project: `webpack in (Compile, fastOpt
 (or `webpack in (projectRef, Compile, fastOptJS in projectRef)` to explicitly scope
 it to another project that the project which is being applied settings).
 
-`npmUpdate`: Downloads NPM dependencies. This task is also scoped to a Scala.js stage.
+`npmUpdate`: Downloads NPM dependencies. This task is scoped by an sbt `Configuration`
+(either `Compile` or `Test`): according to this configuration the directory in
+which the dependencies are downloaded is not the same.
 
 ### Settings {#settings}
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJsonTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJsonTasks.scala
@@ -1,0 +1,49 @@
+package scalajsbundler
+
+import sbt._
+
+object PackageJsonTasks {
+
+  /**
+    * Writes the package.json file that describes the project dependencies
+    * @param targetDir Directory in which write the file
+    * @param npmDependencies NPM dependencies
+    * @param npmDevDependencies NPM devDependencies
+    * @param fullClasspath Classpath
+    * @param configuration Current configuration (Compile or Test)
+    * @param webpackVersion Webpack version
+    * @return The written package.json file
+    */
+  def writePackageJson(
+    targetDir: File,
+    npmDependencies: Seq[(String, String)],
+    npmDevDependencies: Seq[(String, String)],
+    fullClasspath: Seq[Attributed[File]],
+    configuration: Configuration,
+    webpackVersion: String,
+    streams: Keys.TaskStreams
+  ): File = {
+
+    val packageJsonFile = targetDir / "package.json"
+
+    Caching.cached(
+      packageJsonFile,
+      configuration.name,
+      streams.cacheDirectory / s"scalajsbundler-package-json-${if (configuration == Compile) "main" else "test"}"
+    ) { () =>
+      PackageJson.write(
+        streams.log,
+        packageJsonFile,
+        npmDependencies,
+        npmDevDependencies,
+        fullClasspath,
+        configuration,
+        webpackVersion
+      )
+      ()
+    }
+
+    packageJsonFile
+  }
+
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/index-prod.html
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/index-prod.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <div id="container"></div>
-    <script src="target/scala-2.11/static-opt-bundle.js"></script>
+    <script src="target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js"></script>
   </body>
 </html>

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/index.html
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/index.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <div id="container"></div>
-    <script src="target/scala-2.11/static-fastopt-bundle.js"></script>
+    <script src="target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js"></script>
   </body>
 </html>

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/test
@@ -1,11 +1,12 @@
-$ absent target/scala-2.11/static-fastopt-bundle.js target/scala-2.11/static-fastopt-bundle.js.map
+> set enableReloadWorkflow := false
+$ absent target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js.map
 > fastOptJS::webpack
-$ exists target/scala-2.11/static-fastopt-bundle.js target/scala-2.11/static-fastopt-bundle.js.map
+$ exists target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js.map
 > html index.html
 
-$ absent target/scala-2.11/static-opt-bundle.js target/scala-2.11/static-opt-bundle.js.map
+$ absent target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js.map
 > fullOptJS::webpack
-$ exists target/scala-2.11/static-opt-bundle.js target/scala-2.11/static-opt-bundle.js.map
+$ exists target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js.map
 > html index-prod.html
 > checkSize
 
@@ -14,9 +15,9 @@ $ exists target/scala-2.11/static-opt-bundle.js target/scala-2.11/static-opt-bun
 > clean
 > set emitSourceMaps := false
 > fastOptJS::webpack
-$ absent target/scala-2.11/static-fastopt-bundle.js.map
+$ absent target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js.map
 > fullOptJS::webpack
-$ absent target/scala-2.11/static-opt-bundle.js.map
+$ absent target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js.map
 
 # webpackEmitSourceMaps controls source maps emission for the webpack task
 
@@ -24,12 +25,12 @@ $ absent target/scala-2.11/static-opt-bundle.js.map
 > set emitSourceMaps := true
 > set webpackEmitSourceMaps in (Compile, fastOptJS) := false
 > fastOptJS::webpack
-$ exists target/scala-2.11/static-fastopt.js.map
-$ absent target/scala-2.11/static-fastopt-bundle.js.map
+$ exists target/scala-2.11/scalajs-bundler/main/static-fastopt.js.map
+$ absent target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js.map
 
 > set webpackEmitSourceMaps in (Compile, fullOptJS) := false
 > fullOptJS::webpack
-$ exists target/scala-2.11/static-opt.js.map
-$ absent target/scala-2.11/static-opt-bundle.js.map
+$ exists target/scala-2.11/scalajs-bundler/main/static-opt.js.map
+$ absent target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js.map
 
 > test

--- a/sbt-web-scalajs-bundler/src/main/scala/scalajsbundler/NpmAssets.scala
+++ b/sbt-web-scalajs-bundler/src/main/scala/scalajsbundler/NpmAssets.scala
@@ -21,8 +21,8 @@ object NpmAssets {
     */
   def ofProject(project: ProjectReference)(assets: File => PathFinder): Def.Initialize[Task[Seq[PathMapping]]] =
     Def.task {
-      val nodeModules = (crossTarget in project).value / "node_modules" // HACK should be (npmUpdate in project).value
+      val nodeModules = (npmUpdate in (project, Compile)).value / "node_modules"
       assets(nodeModules).pair(relativeTo(nodeModules))
-    }.dependsOn(npmUpdate in (project, Compile, fastOptJS))
+    }
 
 }

--- a/sbt-web-scalajs-bundler/src/main/scala/scalajsbundler/WebScalaJSBundlerPlugin.scala
+++ b/sbt-web-scalajs-bundler/src/main/scala/scalajsbundler/WebScalaJSBundlerPlugin.scala
@@ -49,7 +49,7 @@ object WebScalaJSBundlerPlugin extends AutoPlugin {
           projects
             .map { project =>
               val task = webpack in (project, Compile, sjsStage in project)
-              val clientTarget = crossTarget in (project, sjsStage)
+              val clientTarget = npmUpdate in (project, Compile)
               val sourceMapsEnabled = webpackEmitSourceMaps in (project, Compile, sjsStage in project)
               (task, clientTarget, sourceMapsEnabled).map((files, target, enabled) => files.pair(relativeTo(target)).map((_, enabled)))
             }

--- a/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/test
+++ b/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/test
@@ -1,10 +1,10 @@
--$ exists client/target/scala-2.11/client-fastopt-bundle.js
+$ absent client/target/scala-2.11/scalajs-bundler/main/client-fastopt-bundle.js
 > server/scalaJSDev
-$ exists client/target/scala-2.11/client-fastopt-bundle.js
+$ exists client/target/scala-2.11/scalajs-bundler/main/client-fastopt-bundle.js
 
--$ exists client/target/scala-2.11/client-opt-bundle.js
+$ absent client/target/scala-2.11/scalajs-bundler/main/client-opt-bundle.js
 > server/scalaJSProd
-$ exists client/target/scala-2.11/client-opt-bundle.js
+$ exists client/target/scala-2.11/scalajs-bundler/main/client-opt-bundle.js
 
 > clean
 > server/test


### PR DESCRIPTION
This PR changes the `crossTarget`’s value for `fastOptJS` and `fullOptJS` so that Scala.js artifacts are directly emitted to the directory in which NPM modules are downloaded.