### PR TITLE
#55 Basic conflict resolution mechanism

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
@@ -14,15 +14,17 @@ object PackageJson {
     * @param targetFile File to write into
     * @param npmDependencies NPM dependencies
     * @param npmDevDependencies NPM devDependencies
+    * @param npmResolutions Resolutions to use in case of conflicting dependencies
     * @param fullClasspath Classpath (used to look for dependencies of Scala.js libraries this project depends on)
     * @param currentConfiguration Current configuration
-    * @return The created package.json file (should be `targetDir / "package.json"`)
+    * @return The created package.json file
     */
   def write(
     log: Logger,
     targetFile: File,
     npmDependencies: Seq[(String, String)],
     npmDevDependencies: Seq[(String, String)],
+    npmResolutions: Map[String, String],
     fullClasspath: Seq[Attributed[File]],
     currentConfiguration: Configuration,
     webpackVersion: String
@@ -43,23 +45,63 @@ object PackageJson {
         "source-map-loader" -> "0.1.5" // Used by webpack when emitSourceMaps is enabled
       )
 
-    def filtered(deps: Seq[(String, String)]) =
-      deps
-        .groupBy { case (name, version) => name }
-        .mapValues(_.map(_._2).distinct)
-        .foldRight(List.empty[(String, String)]) { case ((name, versions), result) =>
-          assert(versions.size == 1, s"Different versions of '$name' are required: $versions")
-          (name -> versions.head) :: result
-        }
-
     val packageJson =
       JS.obj(
-        "dependencies" -> JS.objStr(filtered(dependencies)),
-        "devDependencies" -> JS.objStr(filtered(devDependencies))
+        "dependencies" -> JS.objStr(resolveDependencies(dependencies, npmResolutions, log)),
+        "devDependencies" -> JS.objStr(resolveDependencies(devDependencies, npmResolutions, log))
       )
     log.debug("Writing 'package.json'")
     IO.write(targetFile, JS.toJson(packageJson))
     ()
+  }
+
+  /**
+    * Resolves multiple occurrences of a dependency to a same package.
+    *
+    *  - If all the occurrences refer to the same version, pick this one ;
+    *  - If they refer to different versions, pick the one defined in `resolutions` (or fail
+    *    if there is no such resolution).
+    *
+    * @return The resolved dependencies
+    * @param dependencies The dependencies to resolve
+    * @param resolutions The resolutions to use in case of conflict (they will be ignored if there are no conflicts)
+    * @param log Logger
+    */
+  def resolveDependencies(
+    dependencies: Seq[(String, String)],
+    resolutions: Map[String, String],
+    log: Logger
+  ): List[(String, String)] ={
+    val resolvedDependencies =
+      dependencies
+        .groupBy { case (name, version) => name }
+        .mapValues(_.map(_._2).distinct)
+        .foldRight(List.empty[(String, String)]) { case ((name, versions), result) =>
+          val resolvedDependency =
+            versions match {
+              case Seq(single) =>
+                name -> single
+              case _ =>
+                val resolution =
+                  resolutions.getOrElse(name, sys.error(s"Different versions of '$name' are required: $versions, but no “resolution” has been provided."))
+                name -> resolution
+            }
+          resolvedDependency :: result
+        }
+
+    // Add a warning in case a resolution was defined but not used because the corresponding
+    // dependency was not in conflict.
+    val unusedResolutions =
+      resolutions.filter { case (name, resolution) =>
+        resolvedDependencies.exists { case (n, v) => n == name && v != resolution }
+      }
+    if (unusedResolutions.nonEmpty) {
+      log.warn(s"Unused resolutions: $unusedResolutions")
+    }
+
+    log.debug(s"Resolved the following dependencies: $resolvedDependencies")
+
+    resolvedDependencies
   }
 
 }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/PackageJsonTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/PackageJsonTasks.scala
@@ -12,6 +12,7 @@ object PackageJsonTasks {
     * @param targetDir Directory in which write the file
     * @param npmDependencies NPM dependencies
     * @param npmDevDependencies NPM devDependencies
+    * @param npmResolutions Resolutions to use in case of conflicts
     * @param fullClasspath Classpath
     * @param configuration Current configuration (Compile or Test)
     * @param webpackVersion Webpack version
@@ -21,6 +22,7 @@ object PackageJsonTasks {
     targetDir: File,
     npmDependencies: Seq[(String, String)],
     npmDevDependencies: Seq[(String, String)],
+    npmResolutions: Map[String, String],
     fullClasspath: Seq[Attributed[File]],
     configuration: Configuration,
     webpackVersion: String,
@@ -39,6 +41,7 @@ object PackageJsonTasks {
         packageJsonFile,
         npmDependencies,
         npmDevDependencies,
+        npmResolutions,
         fullClasspath,
         configuration,
         webpackVersion

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -101,6 +101,27 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       settingKey[Seq[(String, String)]]("NPM dev dependencies (libraries that the build uses)")
 
     /**
+      * Map of NPM packages (name -> version) to use in case transitive NPM dependencies
+      * refer to a same package but with different version numbers. In such a
+      * case, this setting defines which version should be used for the conflicting
+      * package. Example:
+      *
+      * {{{
+      *   npmResolutions in Compile := Map("react" -> "15.4.1")
+      * }}}
+      *
+      * If several Scala.js projects depend on different versions of `react`, the version `15.4.1`
+      * will be picked. But if all the projects depend on the same version of `react`, the version
+      * given in `npmResolutions` will be ignored.
+      *
+      * Note that this key must be scoped by a `Configuration` (either `Compile` or `Test`).
+      *
+      * @group settings
+      */
+    val npmResolutions: SettingKey[Map[String, String]] =
+      settingKey[Map[String, String]]("NPM dependencies resolutions in case of conflict")
+
+    /**
       * Bundles the output of a Scala.js stage.
       *
       * This task must be scoped by a Scala.js stage (either `fastOptJS` or `fullOptJS`) and
@@ -256,6 +277,8 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
       npmDevDependencies := Seq.empty,
 
+      npmResolutions := Map.empty,
+
       webpack in fullOptJS := webpackTask(fullOptJS).value,
 
       webpack in fastOptJS := Def.taskDyn {
@@ -296,6 +319,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
           (crossTarget in npmUpdate).value,
           npmDependencies.value,
           npmDevDependencies.value,
+          npmResolutions.value,
           fullClasspath.value,
           configuration.value,
           (version in webpack).value,

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/transitive/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/transitive/build.sbt
@@ -1,28 +1,44 @@
 val sub1 =
-  project.in(file("sub1"))
-    .enablePlugins(ScalaJSBundlerPlugin)
+  proj("sub1")
     .settings(
-      scalaVersion := "2.11.8",
       npmDependencies in Compile += "react" -> "15.4.1"
     )
 
 val sub2 =
-  project.in(file("sub2"))
-    .enablePlugins(ScalaJSBundlerPlugin)
+  proj("sub2")
     .settings(
-      scalaVersion := "2.11.8",
       npmDependencies in Compile += "react" -> "15.4.1"
+    )
+
+val sub3 =
+  proj("sub3")
+    .settings(
+      npmDependencies in Compile += "react" -> "15.3.2"
     )
 
 val checkPackageJson = taskKey[Unit]("Check that the package.json file does not contain duplicate entries for the 'react' dependency")
 
-val root =
-  project.in(file("."))
-    .enablePlugins(ScalaJSBundlerPlugin)
+val noConflicts =
+  proj("no-conflicts")
     .settings(
-      scalaVersion := "2.11.8",
       checkPackageJson := {
         val json = IO.read((npmUpdate in Compile).value / "package.json")
         assert(json.split("\n").count(_.containsSlice("react")) == 1, json)
       }
     ).dependsOn(sub1, sub2)
+
+val conflict =
+  proj("conflict")
+    .dependsOn(sub1, sub3)
+
+val resolution =
+  proj("resolution")
+    .dependsOn(sub1, sub3)
+    .settings(
+      npmResolutions in Compile := Map("react" -> "15.4.1")
+    )
+
+def proj(id: String): Project =
+  Project(id, file(id))
+    .enablePlugins(ScalaJSBundlerPlugin)
+    .settings(scalaVersion := "2.11.8")

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/transitive/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/transitive/test
@@ -1,1 +1,4 @@
-> root/checkPackageJson
+> no-conflicts/npmUpdate
+> no-conflicts/checkPackageJson
+-> conflict/npmUpdate
+> resolution/npmUpdate


### PR DESCRIPTION
The resolution mechanism is very manual since it requires the user to explicitly define how dependencies should be resolved.

There is **not** even an automatic resolution system for simple case where only the patch version differs (e.g. `1.0.0` and `1.0.1`). I don’t want to implement such a system in the plugin. A better approach might be to just delegate the resolution process to npm/yarn, but it is not possible in the current state because Scala.js project are not understood by these programs.