### PR TITLE
Make scalaJSBundlerPackageJson accessible

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -230,10 +230,9 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
     val useYarn: SettingKey[Boolean] =
       settingKey[Boolean]("Whether to use yarn for updates")
 
+    val scalaJSBundlerPackageJson =
+      TaskKey[File]("scalaJSBundlerPackageJson", "Write a package.json file defining the NPM dependencies of project")
   }
-
-  private val scalaJSBundlerPackageJson =
-    TaskKey[File]("scalaJSBundlerPackageJson", "Write a package.json file defining the NPM dependencies of project", KeyRanks.Invisible)
 
   private val scalaJSBundlerWebpackConfig =
     TaskKey[File]("scalaJSBundlerWebpackConfig", "Write the webpack configuration file", KeyRanks.Invisible)


### PR DESCRIPTION
The purpose of this PR is to make the `scalaJSBundlerPackageJson` available so anyone can
override to create a custom `package.json`.

## Use Case

I'm trying to build a _sbt-native-packager_ archetype that bundles a complete node application. It includes the complete `node_modules` folder to run the application. In the _production_ build I don't want to include all the dev dependencies, so I want to remove the from the `package.json`. For this reason I want to create a custom `package.json`.