### PR TITLE
Fix #93

### DIFF
--- a/manual/src/ornate/cookbook.md
+++ b/manual/src/ornate/cookbook.md
@@ -36,6 +36,20 @@ file will be copied into the internal target directory, where the scalajs-bundle
 its configuration file, and where all the npm dependencies have been downloaded (so you can
 also `require` these dependencies).
 
+By default `webpack` task only actually launches webpack if it detects changes in
+settings or in the custom webpack config file. Depending on your usage scenario, you might
+want to monitor some other files as well (for example, if your webpack config references
+some additional resources). This can be achieved by using `webpackMonitoredDirectories`
+setting:
+
+~~~ scala
+webpackMonitoredDirectories += baseDirectory.value / "my-scss"
+webpackMonitoredIncludeFilter := "*.scss"
+~~~
+
+More fine-grained control over the list of monitored files is possible by overriding the
+`webpackMonitoredFiles` task.
+
 You can find a working example of custom configuration file
 [here](https://github.com/scalacenter/scalajs-bundler/blob/master/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/prod.webpack.config.js).
 

--- a/manual/src/ornate/cookbook.md
+++ b/manual/src/ornate/cookbook.md
@@ -44,7 +44,7 @@ setting:
 
 ~~~ scala
 webpackMonitoredDirectories += baseDirectory.value / "my-scss"
-webpackMonitoredIncludeFilter := "*.scss"
+includeFilter in webpackMonitoredFiles := "*.scss"
 ~~~
 
 More fine-grained control over the list of monitored files is possible by overriding the

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/PackageJsonTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/PackageJsonTasks.scala
@@ -28,12 +28,21 @@ object PackageJsonTasks {
     webpackVersion: String,
     streams: Keys.TaskStreams
   ): File = {
+ 
+    val hash = Seq(
+      configuration.name,
+      npmDependencies.toString,
+      npmDevDependencies.toString,
+      npmResolutions.toString,
+      fullClasspath.map(_.data.name).toString,
+      webpackVersion
+    ).mkString(",")
 
     val packageJsonFile = targetDir / "package.json"
 
     Caching.cached(
       packageJsonFile,
-      configuration.name,
+      hash,
       streams.cacheDirectory / s"scalajsbundler-package-json-${if (configuration == Compile) "main" else "test"}"
     ) { () =>
       PackageJson.write(

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -208,30 +208,16 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       * Additional directories, monitored for webpack launch.
       *
       * Changes to files in these directories that match
-      * `webpackMonitoredIncludeFilter` enable webpack launch in
-      * `webpack` task.
+      * `includeFilter` scoped to `webpackMonitoredFiles` enable
+      *  webpack launch in `webpack` task.
       *
       * Defaults to an empty `Seq`.
       * 
       * @group settings
-      * @see [[webpackMonitoredIncludeFilter]]
+      * @see [[webpackMonitoredFiles]]
       */
     val webpackMonitoredDirectories: SettingKey[Seq[File]] =
       settingKey[Seq[File]]("Directories, monitored for webpack launch")
-
-    /**
-      * Filter for files, monitored for webpack launch.
-      * 
-      * Changes to files matching this filter in `webpackMonitoredDirectories`
-      * enable webpack launch in `webpack` task.
-      * 
-      * Defaults to `AllPassFilter`
-      * 
-      * @group settings
-      * @see [[webpackMonitoredDirectories]]
-      */
-    val webpackMonitoredIncludeFilter: SettingKey[FileFilter] =
-      settingKey[FileFilter]("Filter for files, monitored for webpack launch")
 
     /**
       * List of files, monitored for webpack launch.
@@ -242,10 +228,9 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       *  - Custom webpack config (if any)
       *  - Files, provided by `webpackEntries` task.
       *  - Files from `webpackMonitoredDirectories`, filtered by
-      *    `webpackMonitoredIncludeFilter`
+      *    `includeFilter`
       *
       * @group settings
-      * @see [[webpackMonitoredIncludeFilter]]
       * @see [[webpackMonitoredDirectories]]
       * @see [[webpack]]
       */
@@ -323,7 +308,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
     // difference between configurations/stages. This way the
     // API user can modify it just once.
     webpackMonitoredDirectories := Seq(),
-    webpackMonitoredIncludeFilter := AllPassFilter
+    (includeFilter in webpackMonitoredFiles) := AllPassFilter
   ) ++
     inConfig(Compile)(perConfigSettings) ++
     inConfig(Test)(perConfigSettings ++ testSettings)
@@ -515,7 +500,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
         val packageJsonFile = scalaJSBundlerPackageJson.value
         val entries = (webpackEntries in stageTask).value
 
-        val filter = (webpackMonitoredIncludeFilter in stageTask).value
+        val filter = (includeFilter in webpackMonitoredFiles).value
         val dirs = (webpackMonitoredDirectories in stageTask).value
 
         val additionalFiles = dirs.flatMap(

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -526,6 +526,9 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
           generatedWebpackConfigFile +:
           customWebpackConfigFile ++:
           entries.map(_._2) ++:
+          // Entries only contain launchers - we need to monitor
+          // Scala.js bundles themselves, too.
+          stageTask.value.data +:
           additionalFiles
       }
     )


### PR DESCRIPTION
Implements changes proposed in #93:
- Fix `scalaJSBundlerPackageJson` caching behavior.
- Expose `webpack` task caching settings.

I had to use a slightly more involved API for monitored files (`webpackMonitoredDirectories` and `webpackMonitoredIncludeFilter` settings, `webpackMonitoredFiles` task). A single file list setting is not flexible enough, and a file list task that is supposed to be overridden is overkill in most cases.

Fixes #93