### PR TITLE
Use a specific version of webpack-dev-server to avoid conflicting dependencies

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ExternalCommand.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ExternalCommand.scala
@@ -31,3 +31,22 @@ class ExternalCommand(name: String) {
 object Npm extends ExternalCommand("npm")
 
 object Yarn extends ExternalCommand("yarn")
+
+object ExternalCommand {
+
+  /**
+    * Locally install NPM packages
+    *
+    * @param installDir The directory in which to install the packages
+    * @param useYarn Whether to use yarn or npm
+    * @param logger sbt logger
+    * @param npmPackages Packages to install (e.g. "webpack", "webpack@2.2.1")
+    */
+  def install(installDir: File, useYarn: Boolean, logger: Logger)(npmPackages: String*): Unit =
+    if (useYarn) {
+      Yarn.run("add" +: npmPackages: _*)(installDir, logger)
+    } else {
+      Npm.run("install" +: npmPackages: _*)(installDir, logger)
+    }
+
+}

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -301,6 +301,8 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       * - `--port` is set to value of `webpackDevServerPort` setting.
       * - Contents of `webpackDevServerExtraArgs` setting.
       *
+      * You can set the webpack-dev-server package version to use with the key `version in startWebpackDevServer`.
+      *
       * @see [[stopWebpackDevServer]]
       * @see [[webpackDevServerPort]]
       * @see [[webpackDevServerExtraArgs]]
@@ -349,6 +351,8 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
     scalaJSModuleKind := ModuleKind.CommonJSModule,
 
     version in webpack := "1.14",
+
+    version in startWebpackDevServer := "1.16.3",
 
     webpackConfigFile := None,
 
@@ -692,6 +696,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       val installDir = target.value / "scalajs-bundler-webpack-dev-server"
       val log = streams.value.log
       val webpackVersion = (version in webpack).value
+      val webpackDevServerVersion = (version in startWebpackDevServer).value
 
       if (!installDir.exists()) {
         log.info(s"Installing webpack-dev-server in ${installDir.absolutePath}")
@@ -700,15 +705,15 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
           Yarn.run(
             "add",
             // Webpack version should match the setting
-            "webpack@" + webpackVersion,
-            "webpack-dev-server"
+            s"webpack@$webpackVersion",
+            s"webpack-dev-server@$webpackDevServerVersion"
           )(installDir, log)
         } else {
           Npm.run(
             "install",
             // Webpack version should match the setting
-            "webpack@" + webpackVersion,
-            "webpack-dev-server"
+            s"webpack@$webpackVersion",
+            s"webpack-dev-server@$webpackDevServerVersion"
           )(installDir, log)
         }
       }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
@@ -4,7 +4,9 @@ enablePlugins(ScalaJSBundlerPlugin)
 
 scalaVersion := "2.11.8"
 
-version in webpack := "2.2.0-rc.3"
+version in webpack := "2.2.1"
+
+version in installWebpackDevServer := "2.2.0"
 
 libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.1"
 


### PR DESCRIPTION
The default webpack-dev-server version now requires webpack 2.0.