### PR TITLE
Support for custom webpack config in reload workflow

### DIFF
--- a/manual/src/ornate/cookbook.md
+++ b/manual/src/ornate/cookbook.md
@@ -72,9 +72,9 @@ In addition to the configured webpack config file, all .js files in the project 
 from the various configuration files.
 
 Here are the steps to share the loader configuration among your prod and dev config files. This
-uses webpack-merge for convenience the same result could be accomplished using plain js only.
+uses webpack-merge for convenience. The same result could be accomplished using plain js only.
 
-1. Put configuration it in a common.webpack.config.js file:
+1. Put configuration in a common.webpack.config.js file:
 
 ~~~ javascript
 module.exports = {

--- a/manual/src/ornate/cookbook.md
+++ b/manual/src/ornate/cookbook.md
@@ -53,6 +53,63 @@ More fine-grained control over the list of monitored files is possible by overri
 You can find a working example of custom configuration file
 [here](https://github.com/scalacenter/scalajs-bundler/blob/master/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/prod.webpack.config.js).
 
+It is also possible to configure a webpack config file to be used in reload workflow and when running the tests.
+This configuration may not contain `entry` and `output` configuration but can be used to configure loaders etc.
+
+These configuration files are configured using `webpackConfigFile in reloadTask` or `webpackConfigFile in Test`.
+For example:
+
+~~~ scala
+webpackConfigFile in webpackReload := Some(baseDirectory.value / "common.webpack.config.js")
+
+webpackConfigFile in Test := Some(baseDirectory.value / "common.webpack.config.js")
+~~~
+
+## Sharing webpack configuration among configuration files {#shared-config}
+
+In addition to the configured webpack config file, all .js files in the project base directory
+(as configured using the `webpackResources` setting) are copied to the target directory so they can be imported
+from the various configuration files.
+
+Here are the steps to share the loader configuration among your prod and dev config files. This
+uses webpack-merge for convenience the same result could be accomplished using plain js only.
+
+1. Put configuration it in a common.webpack.config.js file:
+
+~~~ javascript
+module.exports = {
+  module: {
+    loaders: [
+        ...
+    ],
+    rules: [
+        ...
+    ]
+  }
+}
+~~~
+
+2. Add webpack-merge to your npmDevDependencies:
+
+~~~
+npmDevDependencies in Compile += "webpack-merge" -> "4.1.0"
+~~~
+
+3. Merge in the common configuration in your dev.webpack.js file:
+
+~~~ javascript
+var merge = require("webpack-merge")
+var commonConfig = require("./common.webpack.config.js")
+
+module.exports = merge(commonConfig, {
+    ...
+})
+~~~
+
+You can find a working example of a project using a shared configuration file
+[here](https://github.com/scalacenter/scalajs-bundler/blob/master/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig).
+
+
 ## How to use npm modules from Scala code? {#facade}
 
 Once you have [added npm dependencies](getting-started.md) to the packages you are interested

--- a/manual/src/ornate/reference.md
+++ b/manual/src/ornate/reference.md
@@ -76,16 +76,16 @@ code executable by web browsers takes time. This can be a problem if you rely on
 (like the one of Play framework, for instance), because the reloading time can go up to 30 seconds.
 
 You can get a faster “change source and reload application” workflow by setting the `enableReloadWorkflow` 
-key to `true`.
+key to `true`. An alternative way to invoke reload workflow is using the `fastOptJs::webpackReload` task.
 
 The reload workflow replaces the `fastOptJS::webpack` task implementation with a different one, that does not use 
 webpack to process the output of the Scala.js compilation.  Instead, it pre-bundles the modules imported by your 
 application and exposes them to the global namespace. Since these dependencies can then be resolved from the global 
 namespace, the output of Scala.js is just concatenated after the contents of the pre-bundling process.
 
-> {.note}
-> As soon as `enableReloadWorkflow` is true `fastOptJS::webpack` does **not** use webpack and therefore 
-> the custom webpack configuration file is ignored.
+It is possible to configure an alternative webpack configuration file which is used for building the bundle using the
+"webpackConfigFile in webpackReload" setting . The configuration file may not contain 'entry' nor 'output' configuration
+but can be used to for loaders etc.
 
 ### Tasks and Settings {#tasks-and-settings}
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
@@ -127,6 +127,7 @@ object ReloadWorkflow {
     workingDir: File,
     entryPoint: File,
     bundleFile: File,
+    customWebpackConfigFile: Option[File],
     logger: Logger
   ): Unit = {
     logger.info("Pre-bundling dependencies")
@@ -139,7 +140,13 @@ object ReloadWorkflow {
       )
     IO.write(entryPoint, depsFileContent.show)
 
-    Webpack.run(entryPoint.absolutePath, bundleFile.absolutePath)(workingDir, logger)
+    customWebpackConfigFile match {
+      case Some(configFile) =>
+        Webpack.run("--config", configFile.getAbsolutePath, entryPoint.absolutePath, bundleFile.absolutePath)(workingDir, logger)
+      case None =>
+        Webpack.run(entryPoint.absolutePath, bundleFile.absolutePath)(workingDir, logger)
+
+    }
 
     ()
   }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
@@ -8,6 +8,7 @@ import org.scalajs.sbtplugin.Loggers
 import org.scalajs.sbtplugin.ScalaJSPlugin.AutoImport._
 import sbt._
 
+import scalajsbundler.Webpack.copyToWorkingDir
 import scalajsbundler.util.{Commands, JS}
 
 /**
@@ -128,22 +129,13 @@ object ReloadWorkflow {
     entryPoint: File,
     bundleFile: File,
     customWebpackConfigFile: Option[File],
-    sharedWebpackConfigFiles: Seq[File],
+    webpackResources: Seq[File],
     logger: Logger
   ): Unit = {
     logger.info("Pre-bundling dependencies")
 
-    val customConfigFile =
-      customWebpackConfigFile.map { file =>
-        val configFileCopy = workingDir / file.name
-        IO.copyFile(file, configFileCopy)
-        configFileCopy
-      }
-
-    sharedWebpackConfigFiles.foreach { file =>
-      val sharedConfigFileCopy = workingDir / file.name
-      IO.copyFile(file, sharedConfigFileCopy)
-    }
+    webpackResources.foreach(copyToWorkingDir(workingDir))
+    val customConfigFile = customWebpackConfigFile.map(copyToWorkingDir(workingDir))
 
     val depsFileContent =
       JS.block(

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
@@ -8,9 +8,7 @@ object Webpack {
 
   def copyToWorkingDir(targetDir: File)(file: File): File = {
     val copy = targetDir / file.name
-    if (copy.getAbsolutePath != file.getAbsolutePath && !copy.exists()) {
-      IO.copyFile(file, copy)
-    }
+    IO.copyFile(file, copy)
     copy
   }
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
@@ -84,6 +84,7 @@ object Webpack {
   def bundle(
     generatedWebpackConfigFile: File,
     customWebpackConfigFile: Option[File],
+    sharedWebpackConfigFiles: Seq[File],
     entries: Seq[(String, File)],
     targetDir: File,
     log: Logger
@@ -98,6 +99,11 @@ object Webpack {
         case None =>
           generatedWebpackConfigFile
       }
+
+    sharedWebpackConfigFiles.foreach { file =>
+      val sharedConfigFileCopy = targetDir / file.name
+      IO.copyFile(file, sharedConfigFileCopy)
+    }
 
     log.info("Bundling the application with its NPM dependencies")
     Webpack.run("--config", configFile.absolutePath)(targetDir, log)

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ReloadWorkflowTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ReloadWorkflowTasks.scala
@@ -43,7 +43,7 @@ object ReloadWorkflowTasks {
         val entryPointFile = targetDir / "scalajsbundler-entry-point.js"
         val bundleFile = targetDir / "scalajsbundler-deps.js" // Don’t need to differentiate between stages because the dependencies should not be different between fastOptJS and fullOptJS
         val webpackCfgFile = (webpackConfigFile in webpackReload).value
-        val webpackSharedCfgFiles = webpackSharedConfigFiles.value
+        val webpackResourcesFiles = webpackResources.value.get
 
         val importedModules =
           ReloadWorkflow.findImportedModules(
@@ -64,7 +64,7 @@ object ReloadWorkflowTasks {
             entryPointFile,
             bundleFile,
             webpackCfgFile,
-            webpackSharedCfgFiles,
+            webpackResourcesFiles,
             streams.value.log
           )
         }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ReloadWorkflowTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ReloadWorkflowTasks.scala
@@ -43,6 +43,7 @@ object ReloadWorkflowTasks {
         val entryPointFile = targetDir / "scalajsbundler-entry-point.js"
         val bundleFile = targetDir / "scalajsbundler-deps.js" // Don’t need to differentiate between stages because the dependencies should not be different between fastOptJS and fullOptJS
         val webpackCfgFile = (webpackConfigFile in webpackReload).value
+        val webpackSharedCfgFiles = webpackSharedConfigFiles.value
 
         val importedModules =
           ReloadWorkflow.findImportedModules(
@@ -63,6 +64,7 @@ object ReloadWorkflowTasks {
             entryPointFile,
             bundleFile,
             webpackCfgFile,
+            webpackSharedCfgFiles,
             streams.value.log
           )
         }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ReloadWorkflowTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ReloadWorkflowTasks.scala
@@ -39,8 +39,11 @@ object ReloadWorkflowTasks {
       Def.task {
         val targetDir = (crossTarget in stage).value
         val logger = streams.value.log
+
         val entryPointFile = targetDir / "scalajsbundler-entry-point.js"
         val bundleFile = targetDir / "scalajsbundler-deps.js" // Don’t need to differentiate between stages because the dependencies should not be different between fastOptJS and fullOptJS
+        val webpackCfgFile = (webpackConfigFile in webpackReload).value
+
         val importedModules =
           ReloadWorkflow.findImportedModules(
             linker,
@@ -59,6 +62,7 @@ object ReloadWorkflowTasks {
             targetDir,
             entryPointFile,
             bundleFile,
+            webpackCfgFile,
             streams.value.log
           )
         }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/README.md
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/README.md
@@ -1,0 +1,11 @@
+scalajs-bundler/sharedconfig
+=====================
+
+An application that uses npm packages and that produces
+a static HTML page containing a leaflet map
+
+Demonstrates how to:
+- depend on npm packages ;
+- using custom webpack loader configuration ;
+- use a shared webpack configuration ;
+- differentiate prod/dev builds.

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
@@ -1,0 +1,55 @@
+
+name := "sharedconfig"
+
+enablePlugins(ScalaJSBundlerPlugin)
+
+scalaVersion := "2.11.8"
+
+libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.1"
+
+npmDependencies in Compile += "leaflet" -> "0.7.7"
+npmDevDependencies in Compile ++= Seq(
+  "webpack-merge" -> "4.1.0",
+  "file-loader" -> "0.10.1",
+  "image-webpack-loader" -> "3.3.0",
+  "css-loader" -> "0.27.0",
+  "style-loader" -> "0.16.0"
+)
+
+webpackConfigFile in fastOptJS := Some(baseDirectory.value / "dev.webpack.config.js")
+
+// Use a different Webpack configuration file for production
+webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.config.js")
+
+webpackConfigFile in test := Some(baseDirectory.value / "reload.webpack.config.js")
+
+// Use a different Webpack configuration file for reload workflow
+webpackConfigFile in webpackReload := Some(baseDirectory.value / "reload.webpack.config.js")
+
+webpackSharedConfigFiles := Seq(baseDirectory.value / "common.webpack.config.js")
+
+libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test
+
+// Execute the tests in browser-like environment
+requiresDOM in Test := true
+
+//enableReloadWorkflow := true
+
+useYarn := true
+
+// Check that a HTML can be loaded (and that its JavaScript can be executed) without errors
+InputKey[Unit]("html") := {
+  import complete.DefaultParsers._
+  val page = (Space ~> StringBasic).parsed
+  import com.gargoylesoftware.htmlunit.WebClient
+  val client = new WebClient()
+  try {
+    client.getPage(s"file://${baseDirectory.value.absolutePath}/$page")
+  } finally {
+    client.close()
+  }
+}
+
+TaskKey[Unit]("checkSize") := {
+  assert(IO.readBytes((webpack in (Compile, fullOptJS)).value.head).length == 176387)
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
@@ -26,8 +26,6 @@ webpackConfigFile in test := Some(baseDirectory.value / "reload.webpack.config.j
 // Use a different Webpack configuration file for reload workflow
 webpackConfigFile in webpackReload := Some(baseDirectory.value / "reload.webpack.config.js")
 
-webpackSharedConfigFiles := Seq(baseDirectory.value / "common.webpack.config.js")
-
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test
 
 // Execute the tests in browser-like environment

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
@@ -49,5 +49,5 @@ InputKey[Unit]("html") := {
 }
 
 TaskKey[Unit]("checkSize") := {
-  assert(IO.readBytes((webpack in (Compile, fullOptJS)).value.head).length == 176439)
+  assert(IO.readBytes((webpack in (Compile, fullOptJS)).value.head).length == 176366)
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
@@ -21,17 +21,17 @@ webpackConfigFile in fastOptJS := Some(baseDirectory.value / "dev.webpack.config
 // Use a different Webpack configuration file for production
 webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.config.js")
 
-webpackConfigFile in test := Some(baseDirectory.value / "reload.webpack.config.js")
+// Use the shared Webpack configuration file for reload workflow and for running the tests
+webpackConfigFile in webpackReload := Some(baseDirectory.value / "common.webpack.config.js")
 
-// Use a different Webpack configuration file for reload workflow
-webpackConfigFile in webpackReload := Some(baseDirectory.value / "reload.webpack.config.js")
+webpackConfigFile in Test := Some(baseDirectory.value / "common.webpack.config.js")
 
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test
 
 // Execute the tests in browser-like environment
 requiresDOM in Test := true
 
-//enableReloadWorkflow := true
+enableReloadWorkflow := true
 
 useYarn := true
 
@@ -49,5 +49,5 @@ InputKey[Unit]("html") := {
 }
 
 TaskKey[Unit]("checkSize") := {
-  assert(IO.readBytes((webpack in (Compile, fullOptJS)).value.head).length == 176387)
+  assert(IO.readBytes((webpack in (Compile, fullOptJS)).value.head).length == 176439)
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/common.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/common.webpack.config.js
@@ -22,5 +22,8 @@ module.exports = {
         }
       }
     ]
+  },
+  node: {
+    fs: 'empty'
   }
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/common.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/common.webpack.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+  module: {
+    loaders: [
+     {
+        test: /\.(jpe?g|png|gif|svg)$/i,
+        loaders: [
+          'file?hash=sha512&digest=hex&name=[hash].[ext]',
+          'image-webpack?bypassOnDebug&optimizationLevel=7&interlaced=false'
+        ]
+      }
+    ],
+    rules: [
+      {
+        test: /\.css$/,
+        use: [ 'style-loader', 'css-loader' ]
+      },
+      {
+        test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
+        loader: 'url-loader',
+        options: {
+          limit: 10000
+        }
+      }
+    ]
+  }
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/dev.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/dev.webpack.config.js
@@ -1,19 +1,6 @@
-var merge = require("webpack-merge")
-var commonConfig = require("./common.webpack.config.js")
+var merge = require("webpack-merge");
 
-module.exports = merge(commonConfig, {
+var generatedConfig = require('./scalajs.webpack.config');
+var commonConfig = require("./common.webpack.config.js");
 
-  "entry": {
-    "sharedconfig-fastopt": "./fastopt-launcher.js"
-  },
-  "output": {
-    "filename": "[name]-bundle.js"
-  },
-  "devtool": "source-map",
-  "module": {
-    "preLoaders": [{
-      "test": new RegExp("\\.js$"),
-      "loader": "source-map-loader"
-    }]
-  }
-})
+module.exports = merge(generatedConfig, commonConfig);

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/dev.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/dev.webpack.config.js
@@ -1,0 +1,19 @@
+var merge = require("webpack-merge")
+var commonConfig = require("./common.webpack.config.js")
+
+module.exports = merge(commonConfig, {
+
+  "entry": {
+    "sharedconfig-fastopt": "./fastopt-launcher.js"
+  },
+  "output": {
+    "filename": "[name]-bundle.js"
+  },
+  "devtool": "source-map",
+  "module": {
+    "preLoaders": [{
+      "test": new RegExp("\\.js$"),
+      "loader": "source-map-loader"
+    }]
+  }
+})

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/index-prod.html
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/index-prod.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example</title>
+    <style>
+      #container {
+        width: 12cm;
+        height: 8cm;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container"></div>
+    <script src="target/scala-2.11/scalajs-bundler/main/sharedconfig-opt-bundle.js"></script>
+  </body>
+</html>

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/index.html
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example</title>
+    <style>
+      #container {
+        width: 12cm;
+        height: 8cm;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container"></div>
+    <script src="target/scala-2.11/scalajs-bundler/main/sharedconfig-fastopt-bundle.js"></script>
+  </body>
+</html>

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/prod.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/prod.webpack.config.js
@@ -1,16 +1,11 @@
 var webpack = require('webpack');
-var merge = require("webpack-merge")
+var merge = require("webpack-merge");
 
-var commonConfig = require("./common.webpack.config.js")
+var generatedConfig = require('./scalajs.webpack.config');
+var commonConfig = require("./common.webpack.config.js");
 
-module.exports = merge(commonConfig, {
+module.exports = merge(generatedConfig, commonConfig, {
 
-  "entry": {
-    "sharedconfig-opt": "./opt-launcher.js"
-  },
-  "output": {
-    "filename": "[name]-bundle.js"
-  },
   "plugins": [
     new webpack.optimize.UglifyJsPlugin()
   ]

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/prod.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/prod.webpack.config.js
@@ -1,0 +1,17 @@
+var webpack = require('webpack');
+var merge = require("webpack-merge")
+
+var commonConfig = require("./common.webpack.config.js")
+
+module.exports = merge(commonConfig, {
+
+  "entry": {
+    "sharedconfig-opt": "./opt-launcher.js"
+  },
+  "output": {
+    "filename": "[name]-bundle.js"
+  },
+  "plugins": [
+    new webpack.optimize.UglifyJsPlugin()
+  ]
+})

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/project/build.properties
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.12

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/project/plugins.sbt
@@ -1,0 +1,5 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))
+
+libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.23"

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/reload.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/reload.webpack.config.js
@@ -1,1 +1,0 @@
-module.exports = require('./common.webpack.config.js')

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/reload.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/reload.webpack.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./common.webpack.config.js')

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/src/main/scala/example/Main.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/src/main/scala/example/Main.scala
@@ -1,0 +1,15 @@
+package example
+
+import scala.scalajs.js
+import scala.scalajs.js.JSApp
+import leaflet.modules._
+
+object Main extends JSApp {
+  def main(): Unit = {
+    LeafletAssets
+
+    val map = Leaflet.map("container").setView(js.Array(51.505f, -0.09f), 13)
+    val tileLayer = Leaflet.tileLayer("http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png")
+    map.addLayer(tileLayer)
+  }
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/src/main/scala/leaflet/modules/modules.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/src/main/scala/leaflet/modules/modules.scala
@@ -1,0 +1,33 @@
+package leaflet
+package modules
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.annotation.JSImport.Namespace
+
+@js.native
+trait Map extends js.Object {
+  def setView(center: js.Array[Float], zoom: Int): Map = js.native
+
+  def getZoom(): Int = js.native
+
+  def addLayer(layer: Layer): js.Dynamic = js.native
+}
+
+@js.native
+trait Layer extends js.Object {
+  def addTo(map: Map): js.Dynamic = js.native
+}
+
+@JSImport("leaflet", JSImport.Namespace)
+@js.native
+object Leaflet extends js.Object {
+
+  def map(elem: String): Map = js.native
+
+  def tileLayer(url: String): Layer = js.native
+}
+
+@JSImport("!style-loader!css-loader!leaflet/dist/leaflet.css", JSImport.Default )
+@js.native
+object LeafletAssets extends js.Object {}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/src/test/scala/example/SomeTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/src/test/scala/example/SomeTest.scala
@@ -1,0 +1,21 @@
+package example
+
+import org.scalatest.FreeSpec
+import org.scalajs.dom.document
+
+import scala.scalajs.js
+import leaflet.modules._
+
+class SomeTest extends FreeSpec {
+
+  "leaflet" - {
+    "should return a zoomlevel" in {
+      val container = document.body.innerHTML = """<div id="container" />"""
+
+      val map = Leaflet.map("container").setView(js.Array(51.505f, -0.09f), 13)
+      val zoomlevel = map.getZoom()
+      assert(zoomlevel == 13)
+    }
+  }
+
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/test
@@ -1,0 +1,12 @@
+$ absent target/scala-2.11/scalajs-bundler/main/sharedconfig-fastopt-bundle.js target/scala-2.11/scalajs-bundler/main/sharedconfig-fastopt-bundle.js.map
+> fastOptJS::webpack
+$ exists target/scala-2.11/scalajs-bundler/main/sharedconfig-fastopt-bundle.js target/scala-2.11/scalajs-bundler/main/sharedconfig-fastopt-bundle.js.map
+> html index.html
+
+$ absent target/scala-2.11/scalajs-bundler/main/sharedconfig-opt-bundle.js target/scala-2.11/scalajs-bundler/main/sharedconfig-opt-bundle.js.map
+> fullOptJS::webpack
+$ exists target/scala-2.11/scalajs-bundler/main/sharedconfig-opt-bundle.js
+> html index-prod.html
+> checkSize
+
+> test

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
@@ -37,6 +37,6 @@ InputKey[Unit]("html") := {
 
 TaskKey[Unit]("checkSize") := {
   val artifactSize = IO.readBytes((webpack in (Compile, fullOptJS)).value.head).length
-  val expected = 19810
+  val expected = 19746
   assert(artifactSize == expected, s"expected: $expected, got: $artifactSize")
 }


### PR DESCRIPTION
I implemented this when i ran into an issue using leaflet assets which contain images and require loader configuration (according to my very minimal webpack knowledge..). This failed when using reload workflow. The bundled js is now created using the optional webpack configuration set by "webpackConfigFile in webpackReload"

To be able to scope the setting i added the fastOptJS::webpackReload task which does the same thing as fastOptJS::webpack with reloadWorkflow enabled.

The reloadWorkflow setting still works and also supports the webpackConfigFile setting.

If the approach is ok i'll try to add a test.