### PR TITLE
Handle ImportWithGlobalFallback from scalajs 0.6.17

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val `sbt-scalajs-bundler` =
       sbtPlugin := true,
       name := "sbt-scalajs-bundler",
       description := "Module bundler for Scala.js projects",
-      addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+      addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")
     )
 
 val `sbt-web-scalajs-bundler` =

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
@@ -176,6 +176,7 @@ object ReloadWorkflow {
       linker.linkUnit(irFiles, symbolRequirements, Loggers.sbtLogger2ToolsLogger(logger))
     linkingUnit.classDefs.flatMap(_.jsNativeLoadSpec).collect {
       case JSNativeLoadSpec.Import(module, _) => module
+      case JSNativeLoadSpec.ImportWithGlobalFallback(JSNativeLoadSpec.Import(module, _), _) => module
     }.distinct
   }
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
@@ -173,10 +173,11 @@ object ReloadWorkflow {
       new BasicLinkerBackend(semantics, outputMode, ModuleKind.CommonJSModule, emitSourceMaps, LinkerBackend.Config())
         .symbolRequirements
     val linkingUnit =
-      linker.linkUnit(irFiles, symbolRequirements, Loggers.sbtLogger2ToolsLogger(logger))
-    linkingUnit.classDefs.flatMap(_.jsNativeLoadSpec).collect {
-      case JSNativeLoadSpec.Import(module, _) => module
-      case JSNativeLoadSpec.ImportWithGlobalFallback(JSNativeLoadSpec.Import(module, _), _) => module
+      linker.linkUnit(irFiles, Nil, symbolRequirements, Loggers.sbtLogger2ToolsLogger(logger))
+    linkingUnit.classDefs.flatMap(_.jsNativeLoadSpec).flatMap {
+      case JSNativeLoadSpec.Import(module, _) => List(module)
+      case JSNativeLoadSpec.ImportWithGlobalFallback(JSNativeLoadSpec.Import(module, _), _) => List(module)
+      case JSNativeLoadSpec.Global(_) => Nil
     }.distinct
   }
 


### PR DESCRIPTION
The reload workflow doesn't work properly in case of dependencies that use scalajs 0.6.17 and use @JSImport with globalFallback. This PR adds support for these in the reload workflow.