### PR TITLE
Make package.json private by default (Issue #133)

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
@@ -51,6 +51,7 @@ object PackageJson {
       JSON.obj(
         (
           additionalNpmConfig.toSeq :+
+          "private" -> true :+
           "dependencies" -> JSON.objStr(resolveDependencies(dependencies, npmResolutions, log)) :+
           "devDependencies" -> JSON.objStr(resolveDependencies(devDependencies, npmResolutions, log))
         ): _*


### PR DESCRIPTION
Sets "private" property in the generated package.json to private, to avoid error messages on build. (See #133 for details)