### PR TITLE
[WIP] Update to Scala.js 0.6.18, replace scalaJSLauncher with scalaJSUseMainModuleInitializer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val `sbt-scalajs-bundler` =
       sbtPlugin := true,
       name := "sbt-scalajs-bundler",
       description := "Module bundler for Scala.js projects",
-      addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+      addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
     )
 
 val `sbt-web-scalajs-bundler` =
@@ -23,7 +23,7 @@ val `sbt-web-scalajs-bundler` =
       },
       name := "sbt-web-scalajs-bundler",
       description := "Module bundler for Scala.js projects (integration with sbt-web-scalajs)",
-      addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.2")
+      addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.5")
     )
     .dependsOn(`sbt-scalajs-bundler`)
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ReloadWorkflowTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ReloadWorkflowTasks.scala
@@ -85,7 +85,7 @@ object ReloadWorkflowTasks {
   def writeLauncherTask(stage: TaskKey[Attributed[File]]): Def.Initialize[Task[File]] =
     Def.task {
       val entryPoint =
-        (mainClass in (scalaJSLauncher in stage)).value.getOrElse(sys.error("No main class detected"))
+        (mainClass in (scalaJSMainModuleInitializer in stage)).value.getOrElse(sys.error("No main class detected"))
       val targetDir = (crossTarget in stage).value
       val launcherFile = targetDir / s"scalajsbundler-${stage.key.label}-launcher.js"
       cached(

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/additonalNpmConfig/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/additonalNpmConfig/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/browserless/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/browserless/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/js-resources/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/js-resources/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/transitive/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/transitive/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))
 


### PR DESCRIPTION
Addresses #114 and #137.

Here's my attempt at replacing `scalaJSLauncher` with `scalaJSUseMainModuleInitializer`, which automatically includes a launcher for CommonJS modules.

Stuff that I'm still working on:

* [ ] Make sure all tests pass
* [ ] Replace `scalaJsLauncher` in `sbt-scalajs-bundler/library` test
* [ ] Figure out what can be deleted safely
* [ ] Update relevant docs

I get `AssertionError`s from `checkSize` in the following tests:

* sbt-scalajs-bundler / sharedconfig
* sbt-scalajs-bundler / static
* sbt-scalajs-bundler / library
* sbt-scalajs-bundler / static-webpack2

For example:

```
[info] java.lang.AssertionError: assertion failed: expected: 19410, got: 19790
[info] 	at scala.Predef$.assert(Predef.scala:179)
[info] 	at $ddc5c34c2e2d5af69e15$$anonfun$$sbtdef$1.apply(/tmp/sbt_552c3b52/static/build.sbt:41)
[info] 	at $ddc5c34c2e2d5af69e15$$anonfun$$sbtdef$1.apply(/tmp/sbt_552c3b52/static/build.sbt:38)
[info] 	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
[info] 	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
[info] 	at sbt.std.Transform$$anon$4.work(System.scala:63)
[info] 	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
[info] 	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
[info] 	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
[info] 	at sbt.Execute.work(Execute.scala:237)
[info] 	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
[info] 	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
[info] 	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
[info] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
[info] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[info] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
[info] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
[info] 	at java.lang.Thread.run(Thread.java:748)
[info] [error] (*:checkSize) java.lang.AssertionError: assertion failed: expected: 19410, got: 19790
[info] [error] Total time: 0 s, completed Jul 3, 2017 3:31:08 PM
[error] x sbt-scalajs-bundler / static
[error]    {line 10}  Command failed: checkSize failed
[trace] Stack trace suppressed: run last sbt-scalajs-bundler/*:scripted for the full output.
```