### PR TITLE
Handle ImportWithGlobalFallback from Scala.js 0.6.17 in the reload workflow.

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ReloadWorkflow.scala
@@ -161,8 +161,10 @@ object ReloadWorkflow {
     }
     val linkingUnit =
       linker.linkUnit(irFiles, moduleInitializers, symbolRequirements, Loggers.sbtLogger2ToolsLogger(logger))
-    linkingUnit.classDefs.flatMap(_.jsNativeLoadSpec).collect {
-      case JSNativeLoadSpec.Import(module, _) => module
+    linkingUnit.classDefs.flatMap(_.jsNativeLoadSpec).flatMap {
+      case JSNativeLoadSpec.Import(module, _) => List(module)
+      case JSNativeLoadSpec.ImportWithGlobalFallback(JSNativeLoadSpec.Import(module, _), _) => List(module)
+      case JSNativeLoadSpec.Global(_) => Nil
     }.distinct
   }
 


### PR DESCRIPTION
This is a rebase of https://github.com/scalacenter/scalajs-bundler/pull/131