### PR TITLE
Global modules with jsdom unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.idea

--- a/manual/src/ornate/cookbook.md
+++ b/manual/src/ornate/cookbook.md
@@ -192,22 +192,22 @@ dependency on the facade and to enable the `ScalaJSBundlerPlugin` plugin.
 
 ## How to use an existing facade assuming the JS library to be exposed to the global namespace? {#global-namespace}
 
-Webpack is able to expose modules to the global namespace by using a custom loader:
-[expose-loader](https://github.com/webpack/expose-loader). Thus, you can write a custom webpack configuration
-file that uses this loader to expose the required modules to the global namespace. Typically, this file
-will look like this:
+Webpack is able to require external modules by using [imports-loader](https://github.com/webpack-contrib/imports-loader) 
+and expose them to the global namespace by using [expose-loader](https://github.com/webpack/expose-loader). 
+Thus, you can write a custom webpack configuration file that uses this loaders to expose the required 
+modules to the global namespace. Typically, this file will look like this:
 
-~~~ javascript src=../../../sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace/webpack.config.js
+~~~ javascript src=../../../sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/common.webpack.config.js
 ~~~
 
 Also, tweak your `build.sbt` to add the corresponding NPM dependencies and to use the
 custom webpack configuration file: 
 
-~~~ scala src=../../../sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace/build.sbt#relevant-settings
+~~~ scala src=../../../sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/build.sbt#relevant-settings
 ~~~
 
 You can find a fully working example
-[here](https://github.com/scalacenter/scalajs-bundler/blob/master/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace).
+[here](https://github.com/scalacenter/scalajs-bundler/blob/master/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing).
 
 ## How to bundle an application having several entry points as exports? {#several-entry-points}
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/build.sbt
@@ -1,0 +1,33 @@
+
+name := "global-namespace-with-jsdom-unit-testing"
+
+enablePlugins(ScalaJSBundlerPlugin)
+
+scalaVersion := "2.11.8"
+
+scalaJSUseMainModuleInitializer := true
+
+//#relevant-settings
+libraryDependencies += "ru.pavkin" %%% "scala-js-momentjs" % "0.7.0"
+
+npmDependencies in Compile ++= Seq(
+  "moment" -> "2.18.1"
+)
+
+npmDevDependencies in Compile ++= Seq(
+  "webpack-merge" -> "4.1.0",
+  "imports-loader" -> "0.7.0",
+  "expose-loader" -> "0.7.1"
+)
+
+webpackConfigFile in fastOptJS := Some(baseDirectory.value / "dev.webpack.config.js")
+
+webpackConfigFile in Test := Some(baseDirectory.value / "test.webpack.config.js")
+
+// Execute the tests in browser-like environment
+requiresDOM in Test := true
+//#relevant-settings
+
+libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test
+
+useYarn := true

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/common.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/common.webpack.config.js
@@ -1,0 +1,24 @@
+var globalModules = {
+  moment: "moment"
+};
+
+module.exports = {
+  module: {
+    loaders: [
+      {
+        // Force require global modules
+        test: /.*-(fast|full)opt\.js$/,
+        loader: "imports-loader?" + Object.keys(globalModules).map(function(modName) {
+          return modName + "=" + globalModules[modName];
+        }).join(',')
+      },
+      Object.keys(globalModules).map(function(modName) {
+        // Expose global modules
+        return {
+          test: require.resolve(modName),
+          loader: "expose-loader?" + globalModules[modName]
+        }
+      })
+    ]
+  }
+};

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/dev.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/dev.webpack.config.js
@@ -1,0 +1,6 @@
+var merge = require('webpack-merge');
+
+var commonConfig = require('./common.webpack.config');
+var generatedConfig = require('./scalajs.webpack.config');
+
+module.exports = merge(generatedConfig, commonConfig);

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/project/build.properties
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/src/main/scala/example/Main.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/src/main/scala/example/Main.scala
@@ -1,0 +1,13 @@
+package example
+
+import scala.scalajs.js
+import scala.scalajs.js.JSApp
+import moment._
+
+object Main extends JSApp {
+  def main(): Unit = {
+
+  }
+
+  val getNowInMillis: Double = Moment().value()
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/src/test/scala/example/MainTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/src/test/scala/example/MainTest.scala
@@ -1,0 +1,20 @@
+package example
+
+import org.scalatest.FreeSpec
+
+import scala.scalajs.js
+import scala.scalajs.js.Date
+
+class MainTest extends FreeSpec {
+
+  "getMillis" - {
+    "should return UNIX timestamp" in {
+      val millisBefore = Date.now().toLong
+      val millis = Main.getNowInMillis
+      val millisAfter = Date.now().toLong
+      assert(millis >= millisBefore)
+      assert(millis <= millisAfter)
+    }
+  }
+
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/test
@@ -1,0 +1,2 @@
+> fastOptJS::webpack
+> test

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/test.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/test.webpack.config.js
@@ -1,0 +1,5 @@
+  var merge = require('webpack-merge');
+
+  var commonConfig = require('./common.webpack.config');
+
+  module.exports = merge(commonConfig, {});


### PR DESCRIPTION
Fixes #145.

It adds new test case `global-modules-with-jsdom-unit-testing`
and introduces new webpack config that works for both dev and testing build.

It changes cookbook to reference newly added test case config.