### PR TITLE
Suppress NPM package.json errors

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -15,6 +15,7 @@ import sbt._
 
 import scalajsbundler.ExternalCommand.install
 import scalajsbundler._
+import scalajsbundler.util.JSON
 
 /**
   * This plugin enables `ScalaJSPlugin` and sets the `scalaJSModuleKind` to `CommonJSModule`. It also makes it
@@ -540,7 +541,10 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
       npmResolutions := Map.empty,
 
-      additionalNpmConfig := Map.empty,
+      additionalNpmConfig := Map(
+        "private" -> JSON.bool(true),
+        "license" -> JSON.str("UNLICENSED")
+      ),
 
       webpack in fullOptJS := webpackTask(fullOptJS).value,
 


### PR DESCRIPTION
- Sets the default package.json to private = true, UNLICENSED
  with a blank description. Eliminates the extra error spam from newer
  versions of npm complaining about those fields not being set.