### PR TITLE
Use npm install instead of npm update for package bootstrap

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -572,7 +572,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
             if (useYarn.value) {
               Yarn.run("install", "--non-interactive")(targetDir, log)
             } else {
-              Npm.run("update")(targetDir, log)
+              Npm.run("install")(targetDir, log)
             }
             jsResources.foreach { resource =>
               IO.write(targetDir / resource.relativePath, resource.content)


### PR DESCRIPTION
- Npm update behavior has changed in versions > ~5.0.0