### PR TITLE
Set webpack 3.X as the default version

### DIFF
--- a/manual/src/ornate/changelog.md
+++ b/manual/src/ornate/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 0.9.0-SNAPSHOT
+
+> Not yet released
+
+When upgrading to this release, make sure to migrate your webpack configuration to webpack 3.X https://webpack.js.org/guides/migrating/
+
+- [#666](https://github.com/scalacenter/scalajs-bundler/pull/666): Set webpack 3.X as default version. Run webpack-dev-server within the scalajs-bundler directory, this make shure that loaders are available eagerly.
+
 ## Version 0.8.0
 
 > 2017 September 10

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
@@ -29,7 +29,8 @@ object PackageJson {
     additionalNpmConfig: Map[String, JSON],
     fullClasspath: Seq[Attributed[File]],
     currentConfiguration: Configuration,
-    webpackVersion: String
+    webpackVersion: String,
+    webpackDevServerVersion: String
   ): Unit = {
     val npmManifestDependencies = NpmDependencies.collectFromClasspath(fullClasspath)
     val dependencies =
@@ -43,6 +44,7 @@ object PackageJson {
         else npmManifestDependencies.testDevDependencies
       ) ++ Seq(
         "webpack" -> webpackVersion,
+        "webpack-dev-server" -> webpackDevServerVersion,
         "concat-with-sourcemaps" -> "1.0.4", // Used by the reload workflow
         "source-map-loader" -> "0.1.5" // Used by webpack when emitSourceMaps is enabled
       )

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
@@ -83,7 +83,7 @@ object Webpack {
                   )
                 )
               )
-            case Some(2) | Some(3) =>
+            case Some(2) =>
               Seq(
                 "devtool" -> JS.str("source-map"),
                 "module" -> JS.obj(
@@ -92,6 +92,19 @@ object Webpack {
                       "test" -> JS.regex("\\.js$"),
                       "enforce" -> JS.str("pre"),
                       "loader" -> JS.str("source-map-loader")
+                    )
+                  )
+                )
+              )
+            case Some(3) =>
+              Seq(
+                "devtool" -> JS.str("source-map"),
+                "module" -> JS.obj(
+                  "rules" -> JS.arr(
+                    JS.obj(
+                      "test" -> JS.regex("\\.js$"),
+                      "enforce" -> JS.str("pre"),
+                      "use" -> JS.arr(JS.str("source-map-loader"))
                     )
                   )
                 )

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/WebpackDevServer.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/WebpackDevServer.scala
@@ -12,8 +12,6 @@ private [scalajsbundler] class WebpackDevServer {
   private var worker: Option[Worker] = None
 
   /**
-    * @param npmDir - path to directory containing node_modules
-    * subdirectory.
     * @param workDir - path to working directory for webpack-dev-server
     * @param configPath - path to webpack config.
     * @param port - port, on which the server will operate.
@@ -21,7 +19,6 @@ private [scalajsbundler] class WebpackDevServer {
     * @param logger - a logger to use for output
     */
   def start(
-    npmDir: File,
     workDir: File,
     configPath: File,
     port: Int,
@@ -30,7 +27,6 @@ private [scalajsbundler] class WebpackDevServer {
   ) = this.synchronized {
     stop()
     worker = Some(new Worker(
-      npmDir,
       workDir,
       configPath,
       port,
@@ -47,7 +43,6 @@ private [scalajsbundler] class WebpackDevServer {
   }
 
   private class Worker(
-    npmDir: File,
     workDir: File,
     configPath: File,
     port: Int,
@@ -57,12 +52,9 @@ private [scalajsbundler] class WebpackDevServer {
 
     logger.info("Starting webpack-dev-server");
 
-    val devServerPath = npmDir / "node_modules" /
-    "webpack-dev-server" / "bin" / "webpack-dev-server.js"
-
     val command = Seq(
       "node",
-      devServerPath.absolutePath,
+      "node_modules/webpack-dev-server/bin/webpack-dev-server.js",
       "--config",
       configPath.absolutePath,
       "--port",

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/PackageJsonTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/PackageJsonTasks.scala
@@ -28,6 +28,7 @@ object PackageJsonTasks {
     fullClasspath: Seq[Attributed[File]],
     configuration: Configuration,
     webpackVersion: String,
+    webpackDevServerVersion: String,
     streams: Keys.TaskStreams
   ): BundlerFile.PackageJson = {
 
@@ -37,7 +38,8 @@ object PackageJsonTasks {
       npmDevDependencies.toString,
       npmResolutions.toString,
       fullClasspath.map(_.data.name).toString,
-      webpackVersion
+      webpackVersion,
+      webpackDevServerVersion
     ).mkString(",")
 
     val packageJsonFile = targetDir / "package.json"
@@ -56,7 +58,8 @@ object PackageJsonTasks {
         additionalNpmConfig,
         fullClasspath,
         configuration,
-        webpackVersion
+        webpackVersion,
+        webpackDevServerVersion
       )
       ()
     }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/common.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/common.webpack.config.js
@@ -2,23 +2,29 @@ var globalModules = {
   moment: "moment"
 };
 
+const importRule = 
+  {
+    // Force require global modules
+    test: /.*-(fast|full)opt\.js$/,
+    loader: "imports-loader?" + Object.keys(globalModules).map(function(modName) {
+      return modName + "=" + globalModules[modName];
+    }).join(',')
+  };
+
+
+const exposeRules = 
+  Object.keys(globalModules).map(function(modName) {
+    // Expose global modules
+    return {
+      test: require.resolve(modName),
+      loader: "expose-loader?" + globalModules[modName]
+    }
+  });
+
+const allRules = exposeRules.concat(importRule);
+
 module.exports = {
   module: {
-    loaders: [
-      {
-        // Force require global modules
-        test: /.*-(fast|full)opt\.js$/,
-        loader: "imports-loader?" + Object.keys(globalModules).map(function(modName) {
-          return modName + "=" + globalModules[modName];
-        }).join(',')
-      },
-      Object.keys(globalModules).map(function(modName) {
-        // Expose global modules
-        return {
-          test: require.resolve(modName),
-          loader: "expose-loader?" + globalModules[modName]
-        }
-      })
-    ]
+    rules: allRules
   }
 };

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace/webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace/webpack.config.js
@@ -15,7 +15,7 @@ Object.keys(config.entry).forEach(function(key) {
 });
 
 // Globally expose the JS dependencies
-config.module.loaders = Object.keys(globalModules).map(function (pkg) {
+config.module.rules = Object.keys(globalModules).map(function (pkg) {
   return {
     test: require.resolve(pkg),
     loader: "expose-loader?" + globalModules[pkg]

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
@@ -10,12 +10,14 @@ scalaJSUseMainModuleInitializer := true
 libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.1"
 
 npmDependencies in Compile += "leaflet" -> "0.7.7"
+
 npmDevDependencies in Compile ++= Seq(
   "webpack-merge" -> "4.1.0",
   "file-loader" -> "0.10.1",
   "image-webpack-loader" -> "3.3.0",
   "css-loader" -> "0.27.0",
-  "style-loader" -> "0.16.0"
+  "style-loader" -> "0.18.2",
+  "url-loader" -> "0.5.9"
 )
 
 webpackConfigFile in fastOptJS := Some(baseDirectory.value / "dev.webpack.config.js")

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
@@ -8,7 +8,7 @@ scalaJSUseMainModuleInitializer := true
 
 version in webpack := "2.2.1"
 
-version in installWebpackDevServer := "2.2.0"
+version in startWebpackDevServer := "2.2.0"
 
 libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.1"
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
@@ -45,6 +45,13 @@ TaskKey[Unit]("checkSize") := {
     .get.data
   //#filter-files
   val artifactSize = IO.readBytes(bundleFile).length
-  val expected = 20802
-  assert(artifactSize == expected, s"expected: $expected, got: $artifactSize")
+
+  val sizeLow = 20000
+  val sizeHigh = 22000
+
+  // Account for minor variance in size due to transitive dependency updates
+  assert(
+    artifactSize >= sizeLow && artifactSize <= sizeHigh,
+    s"expected: [$sizeLow, $sizeHigh], got: $artifactSize"
+  )
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/build.sbt
@@ -18,12 +18,59 @@ webpackDevServerPort := 7357
 // (Used by tests only) checks that a HTML can be loaded (and that its JavaScript can be executed) without errors
 InputKey[Unit]("html") := {
   import complete.DefaultParsers._
-  val page = (Space ~> StringBasic).parsed
-  import com.gargoylesoftware.htmlunit.WebClient
-  val client = new WebClient()
-  try {
-    client.getPage(s"http://localhost:7357/$page")
-  } finally {
-    client.close()
+  val ags = Def.spaceDelimited().parsed.toList
+
+  val (page, timeout) = 
+    ags match {
+      case List(page, rawTimeout) => (page, rawTimeout.toInt)
+      case _ => sys.error("expected: page timeout")
+    }
+
+  var totalTime = 0
+  val dt = 1000
+  var connected = false
+  var gotMessage = false
+  
+
+  while(totalTime < timeout && !connected) {
+    import com.gargoylesoftware.htmlunit.WebClient
+    import com.gargoylesoftware.htmlunit.WebConsole.Logger
+
+    val expected = "6051a036-bfb4-4158-a171-950416b5bd9a"
+
+    val client = new WebClient()
+    client.getWebConsole.setLogger(new Logger(){
+      def info(message: Any): Unit = {
+        if (message == expected){
+          gotMessage = true
+        } else {
+          println(s"info $message")
+        }
+      }
+      def debug(message: Any): Unit = println(s"debug: $message")
+      def error(message: Any): Unit = println(s"error: $message")
+      def trace(message: Any): Unit = println(s"trace: $message")
+      def warn(message: Any): Unit = println(s"warn: $message")
+      def isDebugEnabled(): Boolean = true
+      def isErrorEnabled(): Boolean = true
+      def isInfoEnabled(): Boolean = true
+      def isTraceEnabled(): Boolean = true
+      def isWarnEnabled(): Boolean = true
+    })
+
+    try {
+      client.getPage(s"http://localhost:7357/$page")
+      connected = true
+    } catch {
+      case scala.util.control.NonFatal(e) => {
+        println(s"Got $e, Reconnecting")
+      }
+    } finally {
+      client.close()
+    }
+    Thread.sleep(dt)
+    totalTime += dt
   }
+
+  assert(gotMessage, "Did not get println result")
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))
 
-libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.23"
+libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.27"

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/src/main/scala/example/Main.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/src/main/scala/example/Main.scala
@@ -4,6 +4,6 @@ import scala.scalajs.js.JSApp
 
 object Main extends JSApp {
   def main(): Unit = {
-    println("Hello")
+    println("6051a036-bfb4-4158-a171-950416b5bd9a")
   }
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/test
@@ -2,8 +2,7 @@
 > fastOptJS::startWebpackDevServer
 # Give the server some time to launch
 # It's hacky, but this is just a test..
-$ sleep 3000
-> html index.html
+> html index.html 20000
 
 # the server should properly stop
 > fastOptJS::stopWebpackDevServer
@@ -11,7 +10,6 @@ $ sleep 3000
 
 # the server should properly terminate on exit
 > fastOptJS::startWebpackDevServer
-$ sleep 3000
-> html index.html
+> html index.html 20000
 -> exit
 -> html index.html

--- a/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/build.sbt
+++ b/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/build.sbt
@@ -7,7 +7,8 @@ val client =
       libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.1",
       npmDependencies in Compile ++= Seq(
         "snabbdom" -> "0.5.3",
-        "font-awesome" -> "4.7.0"
+        "font-awesome" -> "4.7.0",
+        "url-loader" -> "0.5.9"
       )
     )
 


### PR DESCRIPTION
* fix the source-map syntax for webpack 3.X
* run webpack-dev-server from the same repository as scalajs-bundler