### PR TITLE
Implements new plugin based on npmUpdate

### DIFF
--- a/manual/src/ornate/cookbook.md
+++ b/manual/src/ornate/cookbook.md
@@ -280,3 +280,21 @@ reload on every change:
 ~~~
 webpackDevServerExtraArgs := Seq("--inline")
 ~~~
+
+## How to pass extra parameters to webpack
+
+`scalajs-bundler` invokes `webpack` with a configuration generated either automatically from the build or set with `webpackConfigFile`.
+`webpack` is then called with the following arguments:
+
+~~~
+--bail --config <configfile>
+~~~
+
+You can add extra params to the `webpack` call, for example, to increase debugging
+
+~~~
+webpackExtraArgs := Seq("--profile", "--progress", "true")
+~~~
+
+**Note** Params are passed verbatim, they are not sanitized and could produce errors when passed to webpack.
+In particular, don't attempt to override the `--config` param.

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ExternalCommand.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ExternalCommand.scala
@@ -44,7 +44,7 @@ object ExternalCommand {
     */
   def install(installDir: File, useYarn: Boolean, logger: Logger)(npmPackages: String*): Unit =
     if (useYarn) {
-      Yarn.run("add" +: "--non-interactive" +: npmPackages: _*)(installDir, logger)
+      Yarn.run("add" +: "--mutex" +: "network" +: "--non-interactive" +: npmPackages: _*)(installDir, logger)
     } else {
       Npm.run("install" +: npmPackages: _*)(installDir, logger)
     }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
@@ -75,7 +75,7 @@ object PackageJson {
   /**
     * Resolves multiple occurrences of a dependency to a same package.
     *
-    *  - If all the occurrences refer to the same version, pick this one ;
+    *  - If all the occurrences refer to the same version, pick this one ;
     *  - If they refer to different versions, pick the one defined in `resolutions` (or fail
     *    if there is no such resolution).
     *

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
@@ -67,7 +67,6 @@ object LibraryTasks {
       assert(ensureModuleKindIsCommonJSModule.value)
       val log = streams.value.log
       val emitSourceMaps = (webpackEmitSourceMaps in stage).value
-      val targetDir = npmUpdate.value
       val customWebpackConfigFile = (webpackConfigFile in stage).value
       val generatedWebpackConfigFile =
         (scalaJSBundlerWebpackConfig in stage).value
@@ -78,6 +77,7 @@ object LibraryTasks {
         Seq(generatedWebpackConfigFile.file, entryPointFile.file) ++
         webpackResourceFiles ++ compileResources
       val cacheLocation = streams.value.cacheDirectory / s"${stage.key.label}-webpack-libraries"
+      val extraArgs = (webpackExtraArgs in stage).value
 
       val cachedActionFunction =
         FileFunction.cached(
@@ -95,6 +95,7 @@ object LibraryTasks {
                 webpackResourceFiles,
                 entryPointFile,
                 mode.exportedName,
+                extraArgs,
                 log
               )
               .file)

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/NpmUpdateTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/NpmUpdateTasks.scala
@@ -1,0 +1,55 @@
+package scalajsbundler.sbtplugin
+
+import org.scalajs.core.tools.io.{FileVirtualJSFile, RelativeVirtualFile, VirtualJSFile}
+import org.scalajs.sbtplugin.ScalaJSPlugin.AutoImport.scalaJSNativeLibraries
+import sbt.Keys.{crossTarget, streams}
+import sbt.{Attributed, Def, File, FileFunction, FilesInfo, IO, Task, TaskKey}
+
+import scalajsbundler.{Npm, Yarn}
+import sbt._
+
+import scalajsbundler.BundlerFile.PackageJson
+
+object NpmUpdateTasks {
+  /**
+    * Runs the Npm or Yarn
+    * @param targetDir npm Directory
+    * @param packageJsonFile Json file containing NPM dependencies
+    * @param useYarn Whether to use yarn or npm	
+    * @param jsResources A sequence of javascript resources
+    * @param stream A sbt TaskStream
+    * @return The written npm directory
+    */
+  def npmUpdate(targetDir: File,
+                packageJsonFile: File,
+                useYarn: Boolean,
+                jsResources: Seq[VirtualJSFile with RelativeVirtualFile],
+                streams: Keys.TaskStreams
+                ) = {
+    val log = streams.log
+
+    val cachedActionFunction =
+      FileFunction.cached(
+        streams.cacheDirectory / "scalajsbundler-npm-update",
+        inStyle = FilesInfo.hash
+      ) { _ =>
+        log.info("Updating NPM dependencies")
+        if (useYarn) {
+          Yarn.run("install", "--non-interactive")(targetDir, log)
+        } else {
+          Npm.run("install")(targetDir, log)
+        }
+        jsResources.foreach { resource =>
+          IO.write(targetDir / resource.relativePath, resource.content)
+        }
+        Set.empty
+      }
+
+    cachedActionFunction(Set(packageJsonFile) ++
+      jsResources.collect { case f: FileVirtualJSFile =>
+        f.file
+      }.to[Set])
+
+    targetDir
+  }
+}

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -47,7 +47,7 @@ import scalajsbundler.util.JSON
   * Version of webpack-dev-server to use.
   *
   * {{{
-  *   version in startWebpackDevServer := "2.7.1"
+  *   version in startWebpackDevServer := "2.11.1"
   * }}}
   *
   * == `crossTarget in npmUpdate` ==
@@ -454,7 +454,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
     version in webpack := "3.5.5",
 
-    version in startWebpackDevServer := "2.7.1",
+    version in startWebpackDevServer := "2.11.1",
 
     version in installJsdom := "9.9.0",
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -325,6 +325,18 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       taskKey[Seq[File]]("Files that trigger webpack launch")
 
     /**
+      * Additional arguments to webpack
+      *
+      * Defaults to an empty list.
+      *
+      * @group settings
+      */
+    val webpackExtraArgs = SettingKey[Seq[String]](
+      "webpackExtraArgs",
+      "Custom arguments to webpack"
+    )
+
+    /**
       * Whether to use [[https://yarnpkg.com/ Yarn]] to fetch dependencies instead
       * of `npm`. Yarn has a caching mechanism that makes the process faster.
       *
@@ -467,6 +479,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
     // API user can modify it just once.
     webpackMonitoredDirectories := Seq(),
     (includeFilter in webpackMonitoredFiles) := AllPassFilter,
+    webpackExtraArgs := Seq(),
 
     // The defaults are specified at top level.
     webpackDevServerPort := 8080,

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -485,9 +485,10 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
     installJsdom := {
       val installDir = target.value / "scalajs-bundler-jsdom"
+      val jsdomDir = installDir / "node_modules" / "jsdom"
       val log = streams.value.log
       val jsdomVersion = (version in installJsdom).value
-      if (!installDir.exists()) {
+      if (!jsdomDir.exists()) {
         log.info(s"Installing jsdom in ${installDir.absolutePath}")
         IO.createDirectory(installDir)
         install(installDir, useYarn.value, log)(s"jsdom@$jsdomVersion")

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
@@ -28,6 +28,7 @@ object WebpackTasks {
       val targetDir = npmUpdate.value
       val log = streams.value.log
       val monitoredFiles = (webpackMonitoredFiles in stage).value
+      val extraArgs = (webpackExtraArgs in stage).value
 
       val cachedActionFunction =
         FileFunction.cached(
@@ -42,6 +43,7 @@ object WebpackTasks {
               webpackResourceFiles,
               entriesList,
               targetDir,
+              extraArgs,
               log
             ).file)
         }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/util/Commands.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/util/Commands.scala
@@ -8,6 +8,7 @@ import scala.sys.process.ProcessLogger
 object Commands {
 
   def run(cmd: Seq[String], cwd: File, logger: Logger): Unit = {
+    logger.debug(s"Command: ${cmd.mkString(" ")}")
     val process = Process(cmd, cwd)
     val code = process ! toProcessLogger(logger)
     if (code != 0) {

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/src/main/scala/example/Library.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/src/main/scala/example/Library.scala
@@ -11,8 +11,8 @@ object Library {
 //#library-definition
 
 object SomeOtherCode {
-  import uuid.uuid
+  import uuid.UUID
 
-  def quux(b: Boolean): String = if (b) uuid.v4() else uuid.v1()
+  def quux(b: Boolean): String = if (b) UUID.v4() else UUID.v1()
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/src/main/scala/uuid/uuid.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/src/main/scala/uuid/uuid.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.|
 
 @JSImport("uuid", Namespace)
 @js.native
-object uuid extends UUID
+object UUID extends UUID
 
 @js.native
 trait UUID extends js.Object {

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
@@ -8,7 +8,7 @@ scalaJSUseMainModuleInitializer := true
 
 version in webpack := "2.2.1"
 
-version in startWebpackDevServer := "2.2.0"
+version in startWebpackDevServer := "2.11.1"
 
 libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.1"
 


### PR DESCRIPTION
Here is an implementation of the plugin disscused in #85. The idea is to use npmUpdate to fetch js files without using webpack. 

I introduced a new case class to define which files are required in the npm archives. I like the fact that needed js are defined in the build.sbt and not in @JSImport("module/foo/bar"). And actually without webpack, I think I have no other option. 

It is called NpmDepsPlugin (not very sexy, it can be updated :)). Typically in a project it is used this way:

```scala
npmDeps in Compile += Dep("ace-builds", "1.2.9", List("ace.js", "mode-scala.js", "theme-github.js"))
```
Then a ```dependencyFile``` key enables to get the file containing all the npm js libs are merged.
That's it !

Typically, you can have this facade in a project:
```scala
lazy val ace = project.in(file("ace")) enablePlugins (NpmDepsPlugin) settings (defaultSettings) settings (
  scalaJsDom,
  npmDeps in Compile += Dep("ace-builds", aceVersion, List("ace.js", "mode-scala.js", "theme-github.js"))
  )
```
And then:
```scala
lazy val demo = project.in(file("demo")) enablePlugins (NpmDepsPlugin) settings (defaultSettings) settings(
  libraryDependencies += "com.lihaoyi" %%% "scalarx" % rxVersion,
  libraryDependencies += "com.lihaoyi" %%% "sourcecode" % sourceCodeVersion,
  libraryDependencies += "com.github.karasiq" %%% "scalajs-marked" % "1.0.2",
  runDemo := {

    val demoTarget = target.value
    val demoResource = (resourceDirectory in Compile).value

    val jsTarget = demoTarget / "js"
    val demoJS = (fullOptJS in Compile).value

    IO.copyFile(demoJS.data, jsTarget / "demo.js")
    IO.copyFile(dependencyFile.value, jsTarget / "deps.js")

    IO.copyFile(demoResource / "bootstrap-native.html", demoTarget / "index.html")
  }
) dependsOn(ace)
```
Of cours, new npmDeps can be added in the demo project.

It also work if ace is published as a library.

Some points may be upgraded:
- [x] npmUpdate  have been copy / pasted / modified. Peharps, something more generic could be done to have only one implementation to both ```ScalaJSPlugin``` and ```NpmDepsPlugin```
- [x] Keep only ```npmDependencies``` / ```npmUpdate``` stuff in the ```NpmDepsPlugin``` and start a new plugin project inheriting from ```NpmDepsPlugin```  and implementing the jsDependencies part.