### PR TITLE
Bundler doesn't support version of jsdom more than 9.

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/JSDOMNodeJSEnv.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/JSDOMNodeJSEnv.scala
@@ -54,7 +54,12 @@ class JSDOMNodeJSEnv(
       val jsDOMCode = {
         s"""
            |(function () {
-           |  const jsdom = require("jsdom");
+           |  var jsdom;
+           |  try {
+           |    jsdom = require("jsdom/lib/old-api.js"); // jsdom >= 10.x
+           |  } catch (e) {
+           |    jsdom = require("jsdom"); // jsdom <= 9.x
+           |  }
            |  var windowKeys = [];
            |
            |  jsdom.env({


### PR DESCRIPTION
I installed JSDOM 11.6.1. When I started the test. I got this error.

```
jsdom.createVirtualConsole();
      ^
TypeError: jsdom.createVirtualConsole is not a function
```
This problem relates to this [issue](https://github.com/scala-js/scala-js/issues/2902)
