### PR TITLE
Fix #168: Update the snabbdom facade for Scala.js 1.0

### DIFF
--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/src/main/scala/snabbdom/snabbdom.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/src/main/scala/snabbdom/snabbdom.scala
@@ -20,16 +20,14 @@ object h extends js.Function3[String, js.UndefOr[js.Any], js.UndefOr[js.Any], VN
 }
 
 @js.native
-class VNode(
-  selector: js.UndefOr[String],
-  data: js.UndefOr[VNodeData],
-  children: js.UndefOr[js.Array[VNode | String]],
-  text: js.UndefOr[String],
-  elm: js.UndefOr[Element | Text],
-  key: js.UndefOr[String | Double]
-) extends js.Object
+trait VNode extends js.Object {
+  var selector: js.UndefOr[String] = js.native
+  var data: js.UndefOr[VNodeData]= js.native
+  var children: js.UndefOr[js.Array[VNode | String]]= js.native
+  var text: js.UndefOr[String]= js.native
+  var elm: js.UndefOr[Element | Text]= js.native
+  var key: js.UndefOr[String | Double]= js.native
+}
 
 @js.native
-class VNodeData extends js.Object
-
-
+trait VNodeData extends js.Object

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/src/main/scala/snabbdom/snabbdom.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/src/main/scala/snabbdom/snabbdom.scala
@@ -20,16 +20,16 @@ object h extends js.Function3[String, js.UndefOr[js.Any], js.UndefOr[js.Any], VN
 }
 
 @js.native
-class VNode(
-  selector: js.UndefOr[String],
-  data: js.UndefOr[VNodeData],
-  children: js.UndefOr[js.Array[VNode | String]],
-  text: js.UndefOr[String],
-  elm: js.UndefOr[Element | Text],
-  key: js.UndefOr[String | Double]
-) extends js.Object
+trait VNode extends js.Object {
+  var selector: js.UndefOr[String] = js.native
+  var data: js.UndefOr[VNodeData]= js.native
+  var children: js.UndefOr[js.Array[VNode | String]]= js.native
+  var text: js.UndefOr[String]= js.native
+  var elm: js.UndefOr[Element | Text]= js.native
+  var key: js.UndefOr[String | Double]= js.native
+}
 
 @js.native
-class VNodeData extends js.Object
+trait VNodeData extends js.Object
 
 

--- a/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/client/src/main/scala/snabbdom/snabbdom.scala
+++ b/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/client/src/main/scala/snabbdom/snabbdom.scala
@@ -20,16 +20,14 @@ object h extends js.Function3[String, js.UndefOr[js.Any], js.UndefOr[js.Any], VN
 }
 
 @js.native
-class VNode(
-  selector: js.UndefOr[String],
-  data: js.UndefOr[VNodeData],
-  children: js.UndefOr[js.Array[VNode | String]],
-  text: js.UndefOr[String],
-  elm: js.UndefOr[Element | Text],
-  key: js.UndefOr[String | Double]
-) extends js.Object
+trait VNode extends js.Object {
+  var selector: js.UndefOr[String] = js.native
+  var data: js.UndefOr[VNodeData]= js.native
+  var children: js.UndefOr[js.Array[VNode | String]]= js.native
+  var text: js.UndefOr[String]= js.native
+  var elm: js.UndefOr[Element | Text]= js.native
+  var key: js.UndefOr[String | Double]= js.native
+}
 
 @js.native
-class VNodeData extends js.Object
-
-
+trait VNodeData extends js.Object


### PR DESCRIPTION
This PR changes `VNode` and `VNodeData` from class to trait, since [their JS/TS counterpart are interface](https://github.com/snabbdom/snabbdom/blob/master/src/vnode.ts#L13) therefore those are NOT class. 

The warning for those facades (`JS classes and objects should have an @JSGlobal or @JSImport annotation`) will be resolved, since those 2 types become trait.

If we add `@JSImport` to them, as mentioned in #168, making an instance (`new VNode(...)`) will fail since they does not have constructor in original JS/TS. So I thinks it is better to change them to trait.


