### PR TITLE
Fix #181: Migrate from requiresDOM to JSDOMNodeJSEnv

### DIFF
--- a/manual/src/ornate/reference.md
+++ b/manual/src/ornate/reference.md
@@ -44,7 +44,7 @@ your Scala facades (you can see an example
 If your tests execution environment require the DOM, add the following line to your build:
 
 ~~~ scala
-requiresDOM in Test := true
+jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 ~~~
 
 Then, `ScalaJSBundlerPlugin` will automatically download jsdom and bundle the tests before

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/build.sbt
@@ -25,7 +25,7 @@ webpackConfigFile in fastOptJS := Some(baseDirectory.value / "dev.webpack.config
 webpackConfigFile in Test := Some(baseDirectory.value / "test.webpack.config.js")
 
 // Execute the tests in browser-like environment
-requiresDOM in Test := true
+jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 //#relevant-settings
 
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
@@ -31,7 +31,7 @@ webpackConfigFile in Test := Some(baseDirectory.value / "common.webpack.config.j
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test
 
 // Execute the tests in browser-like environment
-requiresDOM in Test := true
+jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 
 webpackBundlingMode := BundlingMode.LibraryAndApplication()
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
@@ -22,7 +22,7 @@ webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.confi
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test
 
 // Execute the tests in browser-like environment
-requiresDOM in Test := true
+jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 
 useYarn := true
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
@@ -18,7 +18,7 @@ webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.confi
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test
 
 // Execute the tests in browser-like environment
-requiresDOM in Test := true
+jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 
 webpackBundlingMode := BundlingMode.LibraryAndApplication()
 


### PR DESCRIPTION
This PR fixes https://github.com/scalacenter/scalajs-bundler/issues/181