### PR TITLE
Fix #99: Relax NPM dependency version conflict resolution

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
@@ -99,8 +99,10 @@ object PackageJson {
               case Seq(single) =>
                 name -> single
               case _ =>
-                val resolution =
-                  resolutions.getOrElse(name, sys.error(s"Different versions of '$name' are required: $versions, but no “resolution” has been provided."))
+                val resolution = resolutions.get(name) match {
+                  case Some(v) => v
+                  case None => versions.mkString(" ")
+                }
                 name -> resolution
             }
           resolvedDependency :: result

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -136,6 +136,10 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       * will be picked. But if all the projects depend on the same version of `react`, the version
       * given in `npmResolutions` will be ignored.
       *
+      * If different versions of the packages are referred but the package is NOT configured in `npmResolutions`,
+      * a version conflict resolution is delegated to npm/yarn. This behavior may reduce a need to configure
+      * `npmResolutions` explicitly. E.g. "14.4.2" can be automatically-picked for ">=14.0.0 14.4.2 ^14.4.1".
+      *
       * Note that this key must be scoped by a `Configuration` (either `Compile` or `Test`).
       *
       * @group settings

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/transitive/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/transitive/build.sbt
@@ -16,6 +16,12 @@ val sub3 =
       npmDependencies in Compile += "react" -> "15.3.2"
     )
 
+val sub4 =
+  proj("sub4")
+    .settings(
+      npmDependencies in Compile += "react" -> ">=15.3.2"
+    )
+
 val checkPackageJson = taskKey[Unit]("Check that the package.json file does not contain duplicate entries for the 'react' dependency")
 
 val noConflicts =
@@ -37,6 +43,10 @@ val resolution =
     .settings(
       npmResolutions in Compile := Map("react" -> "15.4.1")
     )
+
+val delegatedToPackageManager =
+  proj("delegatedToPackageManager")
+    .dependsOn(sub1, sub4)
 
 def proj(id: String): Project =
   Project(id, file(id))

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/transitive/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/transitive/test
@@ -2,3 +2,4 @@
 > no-conflicts/checkPackageJson
 -> conflict/npmUpdate
 > resolution/npmUpdate
+> delegatedToPackageManager/npmUpdate


### PR DESCRIPTION
This PR fixes https://github.com/scalacenter/scalajs-bundler/issues/99 by delegating version conflict resolution to `npm` or `yarn`, if `npmDependencies` is not provided for a conflicted package.