### PR TITLE
Fix #200: current webpack devserver version does not accept watchOptions

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -47,7 +47,7 @@ import scalajsbundler.util.JSON
   * Version of webpack-dev-server to use.
   *
   * {{{
-  *   version in startWebpackDevServer := "2.7.1"
+  *   version in startWebpackDevServer := "2.11.1"
   * }}}
   *
   * == `crossTarget in npmUpdate` ==
@@ -438,7 +438,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
     version in webpack := "3.5.5",
 
-    version in startWebpackDevServer := "2.7.1",
+    version in startWebpackDevServer := "2.11.1",
 
     version in installJsdom := "9.9.0",
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
@@ -8,7 +8,7 @@ scalaJSUseMainModuleInitializer := true
 
 version in webpack := "2.2.1"
 
-version in startWebpackDevServer := "2.2.0"
+version in startWebpackDevServer := "2.11.1"
 
 libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.1"
 


### PR DESCRIPTION
This PR may fix https://github.com/scalacenter/scalajs-bundler/issues/200

I just updated the dependencies for webpack dev server. I am not sure, but `static-webpack2` test runs successfully, so I think it may be OK 😅 

FYI: There are lots of bugfixes since 2.8.0.

* https://github.com/webpack/webpack-dev-server/releases/tag/v2.11.1
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.11.0
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.10.0
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.9.6
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.9.5
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.9.4
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.9.3
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.9.2
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.9.1
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.9.0
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.8.2
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.8.1
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.8.0
