### PR TITLE
Support passing an extra list of arguments to webpack

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
@@ -67,7 +67,6 @@ object LibraryTasks {
       assert(ensureModuleKindIsCommonJSModule.value)
       val log = streams.value.log
       val emitSourceMaps = (webpackEmitSourceMaps in stage).value
-      val targetDir = npmUpdate.value
       val customWebpackConfigFile = (webpackConfigFile in stage).value
       val generatedWebpackConfigFile =
         (scalaJSBundlerWebpackConfig in stage).value
@@ -78,6 +77,7 @@ object LibraryTasks {
         Seq(generatedWebpackConfigFile.file, entryPointFile.file) ++
         webpackResourceFiles ++ compileResources
       val cacheLocation = streams.value.cacheDirectory / s"${stage.key.label}-webpack-libraries"
+      val extraArgs = (webpackExtraArgs in stage).value
 
       val cachedActionFunction =
         FileFunction.cached(
@@ -95,6 +95,7 @@ object LibraryTasks {
                 webpackResourceFiles,
                 entryPointFile,
                 mode.exportedName,
+                extraArgs,
                 log
               )
               .file)

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -325,6 +325,18 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       taskKey[Seq[File]]("Files that trigger webpack launch")
 
     /**
+      * Additional arguments to webpack
+      *
+      * Defaults to an empty list.
+      *
+      * @group settings
+      */
+    val webpackExtraArgs = SettingKey[Seq[String]](
+      "webpackExtraArgs",
+      "Custom arguments to webpack"
+    )
+
+    /**
       * Whether to use [[https://yarnpkg.com/ Yarn]] to fetch dependencies instead
       * of `npm`. Yarn has a caching mechanism that makes the process faster.
       *
@@ -467,6 +479,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
     // API user can modify it just once.
     webpackMonitoredDirectories := Seq(),
     (includeFilter in webpackMonitoredFiles) := AllPassFilter,
+    webpackExtraArgs := Seq(),
 
     // The defaults are specified at top level.
     webpackDevServerPort := 8080,

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
@@ -28,6 +28,7 @@ object WebpackTasks {
       val targetDir = npmUpdate.value
       val log = streams.value.log
       val monitoredFiles = (webpackMonitoredFiles in stage).value
+      val extraArgs = (webpackExtraArgs in stage).value
 
       val cachedActionFunction =
         FileFunction.cached(
@@ -42,6 +43,7 @@ object WebpackTasks {
               webpackResourceFiles,
               entriesList,
               targetDir,
+              extraArgs,
               log
             ).file)
         }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/util/Commands.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/util/Commands.scala
@@ -8,6 +8,7 @@ import scala.sys.process.ProcessLogger
 object Commands {
 
   def run(cmd: Seq[String], cwd: File, logger: Logger): Unit = {
+    logger.debug(s"Command: ${cmd.mkString(" ")}")
     val process = Process(cmd, cwd)
     val code = process ! toProcessLogger(logger)
     if (code != 0) {


### PR DESCRIPTION
I think it would be useful to be able to pass custom args to webpack so I added this. I'm not very familiar with sbt plugins nor webpack but with this change I'm able to e.g. pass "--profile" which has helped me to find bottlenecks

If you think this is useful I'd add documentation