### PR TITLE
Make library example work in OSX

### DIFF
--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/src/main/scala/example/Library.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/src/main/scala/example/Library.scala
@@ -11,8 +11,8 @@ object Library {
 //#library-definition
 
 object SomeOtherCode {
-  import uuid.uuid
+  import uuid.UUID
 
-  def quux(b: Boolean): String = if (b) uuid.v4() else uuid.v1()
+  def quux(b: Boolean): String = if (b) UUID.v4() else UUID.v1()
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/src/main/scala/uuid/uuid.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/src/main/scala/uuid/uuid.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.|
 
 @JSImport("uuid", Namespace)
 @js.native
-object uuid extends UUID
+object UUID extends UUID
 
 @js.native
 trait UUID extends js.Object {


### PR DESCRIPTION
The library example doesn't work in OSX, as there is a clash on the names `uuid` and `UUID`. This is due to osx's file system isn't case sensitive by default