### PR TITLE
Add --mutex to yarn command

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ExternalCommand.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ExternalCommand.scala
@@ -44,7 +44,7 @@ object ExternalCommand {
     */
   def install(installDir: File, useYarn: Boolean, logger: Logger)(npmPackages: String*): Unit =
     if (useYarn) {
-      Yarn.run("add" +: "--non-interactive" +: npmPackages: _*)(installDir, logger)
+      Yarn.run("add" +: "--mutex" +: "file:/tmp/.yarn-mutex" +: "--non-interactive" +: npmPackages: _*)(installDir, logger)
     } else {
       Npm.run("install" +: npmPackages: _*)(installDir, logger)
     }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ExternalCommand.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/ExternalCommand.scala
@@ -44,7 +44,7 @@ object ExternalCommand {
     */
   def install(installDir: File, useYarn: Boolean, logger: Logger)(npmPackages: String*): Unit =
     if (useYarn) {
-      Yarn.run("add" +: "--mutex" +: "file:/tmp/.yarn-mutex" +: "--non-interactive" +: npmPackages: _*)(installDir, logger)
+      Yarn.run("add" +: "--mutex" +: "network" +: "--non-interactive" +: npmPackages: _*)(installDir, logger)
     } else {
       Npm.run("install" +: npmPackages: _*)(installDir, logger)
     }


### PR DESCRIPTION
Yarn cannot be run in parallel and therefore needs a mutex:
https://yarnpkg.com/lang/en/docs/cli/#toc-concurrency-and-mutex

I ran into this when when building two subprojects in sbt which both use scalajs-bundler.