### PR TITLE
Example application with a custom name

### DIFF
--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/README.md
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/README.md
@@ -1,0 +1,8 @@
+# scalajs-bundler/webpack-assets
+
+An application that uses a more advanced webpack configuration
+
+Demonstrates how to:
+
+* set a custom name for the output file
+* demonstrates bug #192

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
@@ -1,0 +1,41 @@
+import com.gargoylesoftware.htmlunit.WebClient
+import com.gargoylesoftware.htmlunit.WebConsole.Logger
+
+name := "webpack-assets"
+
+enablePlugins(ScalaJSBundlerPlugin)
+
+scalaVersion := "2.12.5"
+
+scalaJSUseMainModuleInitializer := true
+
+//webpackBundlingMode := BundlingMode.LibraryAndApplication()
+
+// Use a custom config file
+webpackConfigFile := Some(baseDirectory.value / "webpack.config.js")
+
+npmDevDependencies in Compile += "html-webpack-plugin" -> "3.0.6"
+
+npmDevDependencies in Compile += "webpack-merge" -> "4.1.2"
+
+webpackDevServerPort := 7357
+
+version in webpack                     := "4.3.0"
+
+version in startWebpackDevServer       := "3.1.1"
+
+// Check that a HTML can be loaded (and that its JavaScript can be executed) without errors
+InputKey[Unit]("html") := {
+  import complete.DefaultParsers._
+  import scala.sys.process._
+
+  val page = (Space ~> StringBasic).parsed
+  import com.gargoylesoftware.htmlunit.WebClient
+  val client = new WebClient()
+  try {
+    val scalajsBundleDir = s"${(npmUpdate in Compile).value.absolutePath}"
+    client.getPage(s"file://$scalajsBundleDir/$page")
+  } finally {
+    client.close()
+  }
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/project/plugins.sbt
@@ -1,0 +1,5 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))
+
+libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.27"

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/src/main/scala/example/Main.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/src/main/scala/example/Main.scala
@@ -1,0 +1,9 @@
+package example
+
+import scala.scalajs.js.JSApp
+
+object Main extends JSApp {
+  def main(): Unit = {
+    println("6051a036-bfb4-4158-a171-950416b5bd9a")
+  }
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
@@ -1,0 +1,3 @@
+# the server should properly start
+-> fastOptJS::webpack
+> html index.html

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/webpack.config.js
@@ -1,0 +1,12 @@
+const ScalaJS = require("./scalajs.webpack.config");
+const Merge = require("webpack-merge");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+const WebApp = Merge(ScalaJS, {
+  output: {
+    filename: "app.js"
+  },
+  plugins: [new HtmlWebpackPlugin()]
+});
+
+module.exports = WebApp;


### PR DESCRIPTION
This is a sample application demonstrating the issue #192 
This is happening because there is a custom name on the webpack configuration. Thus `scalajs-bundler` fails. The test will pass as we are expecting the failure

I'm working on parsing webpack stats to fix this problem