### PR TITLE
Read application asset name from stats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ val `sbt-scalajs-bundler` =
       sbtPlugin := true,
       name := "sbt-scalajs-bundler",
       description := "Module bundler for Scala.js projects",
+      libraryDependencies += "com.typesafe.play" %% "play-json" % "2.6.7",
       addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
     )
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/BundlerFile.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/BundlerFile.scala
@@ -64,10 +64,16 @@ object BundlerFile {
                 .resolve(Library.fileName(project))
                 .toFile)
 
-    def asApplicationBundle: ApplicationBundle =
+    def asDefaultApplicationBundle: ApplicationBundle =
+      ApplicationBundle(project,
+        file.getParentFile.toPath
+          .resolve(ApplicationBundle.fileName(project))
+          .toFile)
+
+    def asApplicationBundle(assetFile: String): ApplicationBundle =
       ApplicationBundle(project,
                         file.getParentFile.toPath
-                          .resolve(ApplicationBundle.fileName(project))
+                          .resolve(assetFile)
                           .toFile)
 
   }
@@ -161,7 +167,8 @@ object BundlerFile {
 
   object ApplicationBundle {
 
-    /** Filename of the generated bundle, given its module entry name */
+    /** Filename of the generated libraries bundle, given its module entry name */
     def fileName(entry: String): String = s"$entry-bundle.js"
   }
+
 }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/BundlerFile.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/BundlerFile.scala
@@ -175,8 +175,7 @@ object BundlerFile {
 
   object ApplicationBundle {
 
-    /** Filename of the generated libraries bundle, given its module entry name */
+    /** Filename of the generated bundle, given its module entry name */
     def fileName(entry: String): String = s"$entry-bundle.js"
   }
-
 }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/BundlerFile.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/BundlerFile.scala
@@ -2,6 +2,8 @@ package scalajsbundler
 
 import java.io.File
 
+import scalajsbundler.Stats.WebpackStats
+
 /**
   * Files used in the `ScalaJSBundler` pipeline.
   */
@@ -54,15 +56,21 @@ object BundlerFile {
     */
   case class WebpackConfig(application: Application, file: java.io.File)
       extends Internal {
-    def project = application.project
+    def project: String = application.project
 
     def targetDir: File = file.getParentFile
 
-    def asLibrary: Library =
+    def asLibrary(stats: Option[WebpackStats]): Library =
       Library(project,
               file.getParentFile.toPath
-                .resolve(Library.fileName(project))
+                .resolve(stats.flatMap(_.assetName(project)).fold(Library.fileName(project))(identity))
                 .toFile)
+
+    def asDefaultLibrary: Library =
+      Library(project,
+        file.getParentFile.toPath
+          .resolve(Library.fileName(project))
+          .toFile)
 
     def asDefaultApplicationBundle: ApplicationBundle =
       ApplicationBundle(project,
@@ -70,10 +78,10 @@ object BundlerFile {
           .resolve(ApplicationBundle.fileName(project))
           .toFile)
 
-    def asApplicationBundle(assetFile: String): ApplicationBundle =
+    def asApplicationBundle(stats: Option[WebpackStats]): ApplicationBundle =
       ApplicationBundle(project,
                         file.getParentFile.toPath
-                          .resolve(assetFile)
+                          .resolve(stats.flatMap(_.assetName(project)).fold(ApplicationBundle.fileName(project))(identity))
                           .toFile)
 
   }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
@@ -11,9 +11,8 @@ import sbt.Logger
  * Webpack stats model and json parsers
  */
 object Stats {
-  final case class Chunk(id: String, size: Long)
-  final case class Asset(name: String, size: Long, emmited: Boolean, chunks: List[String], chunkNames: List[String])
-  final case class WebpackStats(version: String, hash: String, time: Long, errors: List[String], warnings: List[String], assets: List[Asset], chunks: List[Chunk]) {
+  final case class Asset(name: String, size: Long, emmited: Boolean, chunkNames: List[String])
+  final case class WebpackStats(version: String, hash: String, time: Long, errors: List[String], warnings: List[String], assets: List[Asset]) {
     /**
       * Prints to the log an output similar to what webpack pushes to stdout
       */
@@ -30,19 +29,13 @@ object Stats {
       * Note that we only search on files ending on .js skipping e.g. map files
       */
     def assetName(project: String): Option[String] =
-      assets.find(a => a.chunks.contains(project) && a.name.endsWith(".js")).map(_.name)
+      assets.find(a => a.chunkNames.contains(project) && a.name.endsWith(".js")).map(_.name)
   }
-
-  implicit val chunkReads: Reads[Chunk] = (
-    (JsPath \ "id").read[String] and
-    (JsPath \ "size").read[Long]
-  )(Chunk.apply _)
 
   implicit val assetsReads: Reads[Asset] = (
     (JsPath \ "name").read[String] and
     (JsPath \ "size").read[Long] and
     (JsPath \ "emitted").read[Boolean] and
-    (JsPath \\ "chunks").read[List[String]] and
     (JsPath \\ "chunkNames").read[List[String]]
   )(Asset.apply _)
 
@@ -52,8 +45,7 @@ object Stats {
     (JsPath \ "time").read[Long] and
     (JsPath \ "errors").read[List[String]] and
     (JsPath \ "warnings").read[List[String]] and
-    (JsPath \ "assets").read[List[Asset]] and
-    (JsPath \ "chunks").read[List[Chunk]]
+    (JsPath \ "assets").read[List[Asset]]
     )(WebpackStats.apply _)
 
 }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
@@ -14,6 +14,9 @@ object Stats {
   final case class Chunk(id: String, size: Long)
   final case class Asset(name: String, size: Long, emmited: Boolean, chunks: List[String], chunkNames: List[String])
   final case class WebpackStats(version: String, hash: String, time: Long, errors: List[String], warnings: List[String], assets: List[Asset], chunks: List[Chunk]) {
+    /**
+      * Prints to the log an output similar to what webpack pushes to stdout
+      */
     def print(log: Logger): Unit = {
       List(s"Version: $version", s"Hash: $hash", s"Time: ${time}ms", s"Built at ${LocalDateTime.now}").foreach(x => log.info(x))
       errors.foreach(x => log.error(x))
@@ -21,6 +24,13 @@ object Stats {
       warnings.filterNot(_.contains("https://raw.githubusercontent.com")).foreach(x => log.warn(x))
       log.warn(warnings.length.toString)
     }
+
+    /**
+      * Attempts to find the name of the asset for the project name
+      * Note that we only search on files ending on .js skipping e.g. map files
+      */
+    def assetName(project: String): Option[String] =
+      assets.find(a => a.chunks.contains(project) && a.name.endsWith(".js")).map(_.name)
   }
 
   implicit val chunkReads: Reads[Chunk] = (

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
@@ -6,22 +6,67 @@ import java.time.LocalDateTime
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import sbt.Logger
+import scala.math.max
 
 /**
  * Webpack stats model and json parsers
  */
 object Stats {
+
   final case class Asset(name: String, size: Long, emmited: Boolean, chunkNames: List[String])
+
+  object formatting {
+
+    final case class Part(t: String, l: Int) {
+      def maxL(p: Part): Part =
+        copy(l = max(l, p.l))
+
+      def leftPad: String =
+        // String interpolation doesn't support dynamic padding
+        t.reverse.padTo(l, " ").reverse.mkString
+    }
+
+    object Part {
+      def apply(t: String) = new Part(t, t.length)
+    }
+
+    final case class AssetLine(asset: Part, size: Part, emitted: Part, chunks: Part) {
+      def adjustPadding(p: AssetLine): AssetLine = copy(asset.maxL(p.asset), size.maxL(p.size), emitted.maxL(p.emitted), chunks.maxL(p.chunks))
+      def show: String = List(asset, size, emitted, chunks).map(_.leftPad).mkString("   ")
+    }
+
+    object AssetLine {
+      val Zero: AssetLine = AssetLine(Part("Asset"), Part("Size"), Part(""), Part("Chunks"))
+    }
+
+  }
+
   final case class WebpackStats(version: String, hash: String, time: Long, errors: List[String], warnings: List[String], assets: List[Asset]) {
+
     /**
       * Prints to the log an output similar to what webpack pushes to stdout
       */
     def print(log: Logger): Unit = {
+      import formatting._
+      // Print base info
       List(s"Version: $version", s"Hash: $hash", s"Time: ${time}ms", s"Built at ${LocalDateTime.now}").foreach(x => log.info(x))
-      errors.foreach(x => log.error(x))
+      log.info("")
+      // Print the assets
+      assets.map { a =>
+        val emitted = if (a.emmited) "[emitted]" else ""
+        AssetLine(Part(a.name), Part(a.size.toString), Part(emitted), Part(a.chunkNames.mkString("[", ",", "]")))
+      }.foldLeft(List(AssetLine.Zero)) {
+        case (lines, curr) =>
+          val adj = lines.map(_.adjustPadding(curr))
+          val adjNew = adj.headOption.fold(curr)(curr.adjustPadding)
+          (adjNew :: adj.reverse).reverse
+      }.foreach { l =>
+        log.info(l.show)
+      }
+      log.info("")
       // Filtering is a workaround for #111
       warnings.filterNot(_.contains("https://raw.githubusercontent.com")).foreach(x => log.warn(x))
-      log.warn(warnings.length.toString)
+      errors.foreach(x => log.error(x))
     }
 
     /**
@@ -46,6 +91,6 @@ object Stats {
     (JsPath \ "errors").read[List[String]] and
     (JsPath \ "warnings").read[List[String]] and
     (JsPath \ "assets").read[List[Asset]]
-    )(WebpackStats.apply _)
+  )(WebpackStats.apply _)
 
 }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
@@ -1,0 +1,49 @@
+
+package scalajsbundler
+
+import java.time.LocalDateTime
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import sbt.Logger
+
+/**
+ * Webpack stats model and json parsers
+ */
+object Stats {
+  final case class Chunk(id: String, size: Long)
+  final case class Asset(name: String, size: Long, emmited: Boolean, chunks: List[String], chunkNames: List[String])
+  final case class WebpackStats(version: String, hash: String, time: Long, errors: List[String], warnings: List[String], assets: List[Asset], chunks: List[Chunk]) {
+    def print(log: Logger): Unit = {
+      List(s"Version: $version", s"Hash: $hash", s"Time: ${time}ms", s"Built at ${LocalDateTime.now}").foreach(x => log.info(x))
+      errors.foreach(x => log.error(x))
+      // Filtering is a workaround for #111
+      warnings.filterNot(_.contains("https://raw.githubusercontent.com")).foreach(x => log.warn(x))
+      log.warn(warnings.length.toString)
+    }
+  }
+
+  implicit val chunkReads: Reads[Chunk] = (
+    (JsPath \ "id").read[String] and
+    (JsPath \ "size").read[Long]
+  )(Chunk.apply _)
+
+  implicit val assetsReads: Reads[Asset] = (
+    (JsPath \ "name").read[String] and
+    (JsPath \ "size").read[Long] and
+    (JsPath \ "emitted").read[Boolean] and
+    (JsPath \\ "chunks").read[List[String]] and
+    (JsPath \\ "chunkNames").read[List[String]]
+  )(Asset.apply _)
+
+  implicit val statsReads: Reads[WebpackStats] = (
+    (JsPath \ "version").read[String] and
+    (JsPath \ "hash").read[String] and
+    (JsPath \ "time").read[Long] and
+    (JsPath \ "errors").read[List[String]] and
+    (JsPath \ "warnings").read[List[String]] and
+    (JsPath \ "assets").read[List[Asset]] and
+    (JsPath \ "chunks").read[List[Chunk]]
+    )(WebpackStats.apply _)
+
+}

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
@@ -251,6 +251,7 @@ object Webpack {
     val parsed = Json.parse(in)
     parsed.validate[WebpackStats] match {
       case JsError(e) =>
+        logger.error("Error parsing webpack stats output")
         // In case of error print the result and return None. it will be ignored upstream
         e.foreach {
           case (p, v) => logger.error(s"$p: ${v.mkString(",")}")

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
@@ -193,9 +193,7 @@ object Webpack {
     stats.foreach(_.print(log))
 
     // Attempt to discover the actual name produced by webpack indexing by chunk name and discarding maps
-    val producedName = stats.flatMap(_.assets.find(a => a.chunks.contains(generatedWebpackConfigFile.application.project) && a.name.endsWith(".js"))).map(_.name)
-    val bundle = producedName.fold(generatedWebpackConfigFile.asDefaultApplicationBundle)(generatedWebpackConfigFile.asApplicationBundle)
-    println("Expected bundle " + bundle.project)
+    val bundle = generatedWebpackConfigFile.asApplicationBundle(stats)
     assert(bundle.file.exists(), "Webpack failed to create application bundle")
     bundle
   }
@@ -241,8 +239,9 @@ object Webpack {
     val args = extraArgs ++: Seq("--config", configFile.absolutePath)
     val stats = Webpack.run(args: _*)(generatedWebpackConfigFile.targetDir, log)
     stats.foreach(_.print(log))
+    println(stats.map(_.assets))
 
-    val library = generatedWebpackConfigFile.asLibrary
+    val library = generatedWebpackConfigFile.asLibrary(stats)
     assert(library.file.exists, "Webpack failed to create library file")
     library
   }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
@@ -104,7 +104,7 @@ object LibraryTasks {
 
         }
       cachedActionFunction(monitoredFiles.to[Set])
-      generatedWebpackConfigFile.asLibrary
+      generatedWebpackConfigFile.asDefaultLibrary
     }
 
   private[sbtplugin] def loader(

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
@@ -104,7 +104,7 @@ object LibraryTasks {
 
         }
       cachedActionFunction(monitoredFiles.to[Set])
-      generatedWebpackConfigFile.asDefaultLibrary
+      generatedWebpackConfigFile.asLibrary(None)
     }
 
   private[sbtplugin] def loader(

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -536,11 +536,11 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       ),
 
       npmUpdate := NpmUpdateTasks.npmUpdate(
-	(crossTarget in npmUpdate).value,
-	scalaJSBundlerPackageJson.value.file,
-	useYarn.value,
-	scalaJSNativeLibraries.value.data,
-	streams.value),
+      (crossTarget in npmUpdate).value,
+      scalaJSBundlerPackageJson.value.file,
+      useYarn.value,
+      scalaJSNativeLibraries.value.data,
+      streams.value),
 
       scalaJSBundlerPackageJson :=
         PackageJsonTasks.writePackageJson(
@@ -731,9 +731,8 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
         val generatedFiles: Seq[File] = Seq(
           packageJsonFile.file,
-          generatedWebpackConfigFile.file ,
-          entry.file
-        )
+          generatedWebpackConfigFile.file,
+          entry.file)
         val additionalFiles: Seq[File] = dirs.flatMap(
           dir => (dir ** filter).get
         )

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
@@ -51,6 +51,6 @@ object WebpackTasks {
             ).file)
         }
       cachedActionFunction(monitoredFiles.to[Set])
-      Seq(generatedWebpackConfigFile.asApplicationBundle.asAttributedFile)
+      Seq(generatedWebpackConfigFile.asDefaultApplicationBundle.asAttributedFile)
     }
 }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
@@ -12,7 +12,7 @@ object WebpackTasks {
   : Def.Initialize[Task[BundlerFile.Application]] =
     Def.task {
       val projectName = stage.value.data.name.stripSuffix(".js")
-      BundlerFile.Application(projectName, stage.value.data)
+      BundlerFile.Application(projectName, stage.value.data, Nil)
     }
 
   private[sbtplugin] def webpack(
@@ -51,6 +51,6 @@ object WebpackTasks {
             ).file)
         }
       cachedActionFunction(monitoredFiles.to[Set])
-      Seq(generatedWebpackConfigFile.asDefaultApplicationBundle.asAttributedFile)
+      Seq(generatedWebpackConfigFile.asApplicationBundle(None).asAttributedFile)
     }
 }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/util/Commands.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/util/Commands.scala
@@ -1,20 +1,29 @@
 package scalajsbundler.util
 
 import sbt.Logger
-import java.io.File
+import java.io.{InputStream, File}
 import scala.sys.process.Process
+import scala.sys.process.BasicIO
 import scala.sys.process.ProcessLogger
 
 object Commands {
 
-  def run(cmd: Seq[String], cwd: File, logger: Logger): Unit = {
+  def run(cmd: Seq[String], cwd: File, logger: Logger, ouputProcess: InputStream => Unit): Unit = {
+    val toErrorLog = (is: InputStream) => scala.io.Source.fromInputStream(is).getLines.foreach(msg => logger.error(msg))
+
     logger.debug(s"Command: ${cmd.mkString(" ")}")
     val process = Process(cmd, cwd)
-    val code = process ! toProcessLogger(logger)
+    val processIO = BasicIO.standard(false).withOutput(ouputProcess).withError(toErrorLog)
+    val code: Int = process.run(processIO).exitValue()
     if (code != 0) {
       sys.error(s"Non-zero exit code: $code")
     }
     ()
+  }
+
+  def run(cmd: Seq[String], cwd: File, logger: Logger): Unit = {
+    val toInfoLog = (is: InputStream) => scala.io.Source.fromInputStream(is).getLines.foreach(msg => logger.error(msg))
+    run(cmd, cwd, logger, toInfoLog)
   }
 
   def start(cmd: Seq[String], cwd: File, logger: Logger): Process =

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/util/Commands.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/util/Commands.scala
@@ -8,22 +8,30 @@ import scala.sys.process.ProcessLogger
 
 object Commands {
 
-  def run(cmd: Seq[String], cwd: File, logger: Logger, ouputProcess: InputStream => Unit): Unit = {
+  def run[A](cmd: Seq[String], cwd: File, logger: Logger, outputProcess: InputStream => A): Option[A] = {
     val toErrorLog = (is: InputStream) => scala.io.Source.fromInputStream(is).getLines.foreach(msg => logger.error(msg))
+
+    // Unfortunately a var is the only way to capture the result
+    var result: Option[A] = None
+    def outputCapture(o: InputStream): Unit = {
+      result = Some(outputProcess(o))
+      ()
+    }
 
     logger.debug(s"Command: ${cmd.mkString(" ")}")
     val process = Process(cmd, cwd)
-    val processIO = BasicIO.standard(false).withOutput(ouputProcess).withError(toErrorLog)
+    val processIO = BasicIO.standard(false).withOutput(outputCapture).withError(toErrorLog)
     val code: Int = process.run(processIO).exitValue()
     if (code != 0) {
       sys.error(s"Non-zero exit code: $code")
     }
-    ()
+    result
   }
 
   def run(cmd: Seq[String], cwd: File, logger: Logger): Unit = {
     val toInfoLog = (is: InputStream) => scala.io.Source.fromInputStream(is).getLines.foreach(msg => logger.error(msg))
     run(cmd, cwd, logger, toInfoLog)
+    ()
   }
 
   def start(cmd: Seq[String], cwd: File, logger: Logger): Process =

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/README.md
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/README.md
@@ -1,0 +1,8 @@
+# scalajs-bundler/webpack-assets
+
+An application that uses a more advanced webpack configuration
+
+Demonstrates how to:
+
+* set a custom name for the output file
+* demonstrates bug #192

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/README.md
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/README.md
@@ -1,8 +1,9 @@
 # scalajs-bundler/webpack-assets
 
-An application that uses a more advanced webpack configuration
+An application that uses an advanced webpack configuration
 
 Demonstrates how to:
 
 * set a custom name for the output file
-* demonstrates bug #192
+* demonstrates bug #192 and its fix
+* Use a different mode and configuration file for dev and production

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
@@ -9,10 +9,15 @@ scalaVersion := "2.12.5"
 
 scalaJSUseMainModuleInitializer := true
 
-//webpackBundlingMode := BundlingMode.LibraryAndApplication()
+// Use library mode for fastOptJS
+webpackBundlingMode in fastOptJS := BundlingMode.LibraryOnly()
 
-// Use a custom config file
-webpackConfigFile := Some(baseDirectory.value / "webpack.config.js")
+webpackConfigFile in fastOptJS := Some(baseDirectory.value / "dev.config.js")
+
+// Use application model mode for fullOptJS
+webpackBundlingMode in fullOptJS := BundlingMode.Application
+
+webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.config.js")
 
 npmDevDependencies in Compile += "html-webpack-plugin" -> "3.0.6"
 
@@ -20,9 +25,11 @@ npmDevDependencies in Compile += "webpack-merge" -> "4.1.2"
 
 webpackDevServerPort := 7357
 
-version in webpack                     := "4.3.0"
+useYarn := true
 
-version in startWebpackDevServer       := "3.1.1"
+version in webpack                     := "4.5.0"
+
+version in startWebpackDevServer       := "3.1.3"
 
 // Check that a HTML can be loaded (and that its JavaScript can be executed) without errors
 InputKey[Unit]("html") := {

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
@@ -1,0 +1,41 @@
+import com.gargoylesoftware.htmlunit.WebClient
+import com.gargoylesoftware.htmlunit.WebConsole.Logger
+
+name := "webpack-assets"
+
+enablePlugins(ScalaJSBundlerPlugin)
+
+scalaVersion := "2.12.5"
+
+scalaJSUseMainModuleInitializer := true
+
+//webpackBundlingMode := BundlingMode.LibraryAndApplication()
+
+// Use a custom config file
+webpackConfigFile := Some(baseDirectory.value / "webpack.config.js")
+
+npmDevDependencies in Compile += "html-webpack-plugin" -> "3.0.6"
+
+npmDevDependencies in Compile += "webpack-merge" -> "4.1.2"
+
+webpackDevServerPort := 7357
+
+version in webpack                     := "4.3.0"
+
+version in startWebpackDevServer       := "3.1.1"
+
+// Check that a HTML can be loaded (and that its JavaScript can be executed) without errors
+InputKey[Unit]("html") := {
+  import complete.DefaultParsers._
+  import scala.sys.process._
+
+  val page = (Space ~> StringBasic).parsed
+  import com.gargoylesoftware.htmlunit.WebClient
+  val client = new WebClient()
+  try {
+    val scalajsBundleDir = s"${(npmUpdate in Compile).value.absolutePath}"
+    client.getPage(s"file://$scalajsBundleDir/$page")
+  } finally {
+    client.close()
+  }
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/dev.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/dev.config.js
@@ -3,8 +3,9 @@ const Merge = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 const WebApp = Merge(ScalaJS, {
+  mode: "development",
   output: {
-    filename: "app.js"
+    filename: "library.js"
   },
   plugins: [new HtmlWebpackPlugin()]
 });

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/prod.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/prod.config.js
@@ -1,0 +1,13 @@
+const ScalaJS = require("./scalajs.webpack.config");
+const Merge = require("webpack-merge");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+const WebApp = Merge(ScalaJS, {
+  mode: "production",
+  output: {
+    filename: "app.js"
+  },
+  plugins: [new HtmlWebpackPlugin()]
+});
+
+module.exports = WebApp;

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/project/plugins.sbt
@@ -1,0 +1,5 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))
+
+libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.27"

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/src/main/scala/example/Main.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/src/main/scala/example/Main.scala
@@ -1,0 +1,9 @@
+package example
+
+import scala.scalajs.js.JSApp
+
+object Main extends JSApp {
+  def main(): Unit = {
+    println("6051a036-bfb4-4158-a171-950416b5bd9a")
+  }
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
@@ -1,3 +1,3 @@
 # the server should properly start
--> fastOptJS::webpack
+> fastOptJS::webpack
 > html index.html

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
@@ -1,0 +1,3 @@
+# the server should properly start
+-> fastOptJS::webpack
+> html index.html

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
@@ -1,3 +1,8 @@
 # the server should properly start
 > fastOptJS::webpack
 > html index.html
+> clean
+
+# Now let's try optimized
+> fullOptJS::webpack
+> html index.html

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/webpack.config.js
@@ -1,0 +1,12 @@
+const ScalaJS = require("./scalajs.webpack.config");
+const Merge = require("webpack-merge");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+const WebApp = Merge(ScalaJS, {
+  output: {
+    filename: "app.js"
+  },
+  plugins: [new HtmlWebpackPlugin()]
+});
+
+module.exports = WebApp;


### PR DESCRIPTION
This PR aims to fix #192 and also lays some tools for future improvements.
#192 Happens because `scalajs-bundler` writes a given output file name and assumes `webpack` will produce an asset with that name. However this is not necessarily true if a custom webpack configuration is used. It would be better to ask webpack for the actual name of the asset.

On this PR the stats output of webpack is parsed to discover the actual name of the asset. The output is parsed using `play-json` and a minimal mini model is extracted. Note that the documentation on `stats` output is not totally reliable, some elements are sometimes `String` while others `Int` .

With stats we can learn what the real output file name is and use that in the plugin. In the future we can use this info to extract other useful information.

One important side effect of this. The json output takes over the regular webpack's std output, thus becoming silent which is not that nice. This PR tries to recover some of that by printing info about the build like

```
[info] [info] Version: 4.5.0
[info] [info] Hash: 06f297ae3a9e2b2b5c7d
[info] [info] Time: 1203ms
[info] [info] Built at 2018-04-11T14:03:28.254
[info] [info]
[info] [info]      Asset    Size                             Chunks
[info] [info]     app.js   11840   [emitted]   [webpack-assets-opt]
[info] [info] app.js.map   27145   [emitted]   [webpack-assets-opt]
[info] [info] index.html     179   [emitted]                     []
[info] [info]
```

This also lets me filter out warnings and thus fixes #111 

An example test is included for both `Library` and `Application` mode in `fastOptJS` and `fullOptJS`

