### PR TITLE
add function as a module example

### DIFF
--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/src/main/resources/function.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/src/main/resources/function.js
@@ -1,0 +1,1 @@
+module.exports = (first, second) => `Konrad says ${first} plus ${second} is ${first + second}`;

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/src/main/scala/example/Main.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/src/main/scala/example/Main.scala
@@ -9,6 +9,7 @@ object Main extends JSApp {
     println(Member(42))
     val user = new User("Julien", 30)
     println(user.name)
+    println(Func(8, 12))
   }
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/src/main/scala/example/facades.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/src/main/scala/example/facades.scala
@@ -13,6 +13,13 @@ object Obj extends js.Object {
   def bar(i: Int): Int = js.native
 }
 
+// --- Import a whole module as a function
+
+@JSImport("./function.js", JSImport.Default)
+@js.native
+object Func extends js.Function2[Int, Int, String] {
+  def apply(first: Int, second: Int): String = js.native
+}
 
 // --- Import just a module member, which is a function
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/src/test/scala/example/FacadesTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/src/test/scala/example/FacadesTest.scala
@@ -12,6 +12,14 @@ class FacadesTest extends FreeSpec {
 
   }
 
+  "Func" - {
+
+    "acts as a function" in {
+      assert(Func(2, 5) == "Konrad says 2 plus 5 is 7")
+    }
+
+  }
+
   "Member" - {
 
     "can be called as a function" in {


### PR DESCRIPTION
Added example for importing function as a module
module.exports = function () {}
like camelcase in npm
