### PR TITLE
Fix thread leak

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -574,7 +574,10 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
     val prev = createdTestAdapters.get()
     val r = new TestAdapter(jsEnv, config)
     if (createdTestAdapters.compareAndSet(prev, r :: prev)) r
-    else newTestAdapter(jsEnv, config)
+    else {
+      r.close()
+      newTestAdapter(jsEnv, config)
+    }
   }
 
   private def closeAllTestAdapters(): Unit =
@@ -683,7 +686,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
           .withJSConsole(console)
           .withModuleSettings(moduleKind, moduleIdentifier)
 
-        val adapter = new TestAdapter(env, config)
+        val adapter = newTestAdapter(env, config)
         val frameworkAdapters = adapter.loadFrameworks(frameworkNames)
 
         frameworks.zip(frameworkAdapters).collect {


### PR DESCRIPTION
I noticed that my tests were leaking ComJSEnvRPC threads. I tracked it
down to the code in the loadedTestFrameworks settings definition in the
ScalaJSBundlerPlugin which initializes, but does not register the
adapter in the createdTestAdapters list.

I also noticed that newTestAdapter would leak threads in the recursive
case (which probably doesn't happen often in the real world).