### PR TITLE
Bugfix parsing errors on the output

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
@@ -23,7 +23,7 @@ object Stats {
 
       def leftPad: String =
         // String interpolation doesn't support dynamic padding
-        t.reverse.padTo(l, " ").reverse.mkString
+        t.reverse.padTo(l, ' ').reverse.mkString
     }
 
     object Part {

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/badconfig1.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/badconfig1.js
@@ -1,0 +1,15 @@
+const ScalaJS = require("./scalajs.webpack.config");
+const Merge = require("webpack-merge");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+// LessLoader is requested but it is missing from npmDevDependencies
+const LessLoaderPlugin = require("less-loader");
+
+const WebApp = Merge(ScalaJS, {
+  mode: "development",
+  output: {
+    filename: "library.js"
+  },
+  plugins: [new HtmlWebpackPlugin()]
+});
+
+module.exports = WebApp;

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
@@ -27,7 +27,7 @@ webpackDevServerPort := 7357
 
 useYarn := true
 
-version in webpack                     := "4.5.0"
+version in webpack                     := "4.6.0"
 
 version in startWebpackDevServer       := "3.1.3"
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
@@ -6,3 +6,8 @@
 # Now let's try optimized
 > fullOptJS::webpack
 > html index.html
+
+# Error case 1
+> set webpackConfigFile in fastOptJS := Some(new File("badconfig1.js"))
+> clean
+-> fastOptJS::webpack


### PR DESCRIPTION
While testing I've found some cases not properly handled with the changes on # 234. In this case, the webpack refers to an unknown module and the error goes to stdout interfering with the output parsing.

An example is included where the webpack config refers to `less-loader` which hasn't been included as a dependency. Before this patch the error message wasn't displayed correctly and sbt wouldn't complete