### PR TITLE
Update concat-with-sourcemaps

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
@@ -62,7 +62,7 @@ object PackageJson {
         else npmManifestDependencies.testDevDependencies
       ) ++ webpackPackages ++ Seq(
         "webpack-dev-server" -> webpackDevServerVersion,
-        "concat-with-sourcemaps" -> "1.0.4", // Used by the reload workflow
+        "concat-with-sourcemaps" -> "1.0.7", // Used by the reload workflow
         "source-map-loader" -> sourceMapLoaderVersion // Used by webpack when emitSourceMaps is enabled
       )
 


### PR DESCRIPTION
Small update of `conact-with-sourcemaps`. Otherwise we get the message:

```
warning concat-with-sourcemaps@1.0.4: important fix in v1.0.6
```