### PR TITLE
Use Public path from webpack stats

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/BundlerFile.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/BundlerFile.scala
@@ -65,22 +65,25 @@ object BundlerFile {
       */
     def asLibrary(stats: Option[WebpackStats]): Library =
       Library(project,
-              targetDir
-                .resolve(stats.flatMap(_.assetName(project)).fold(Library.fileName(project))(identity))
-                .toFile,
-              stats.map(_.assets.map(a => targetDir.resolve(a.name).toFile)).getOrElse(Nil))
+              stats.flatMap { s =>
+                s.resolveAsset(targetDir, project)
+              }.getOrElse(targetDir.resolve(Library.fileName(project)).toFile),
+              stats.map { s =>
+                s.resolveAllAssets(targetDir)
+              }.getOrElse(Nil)
+            )
 
     /**
       * Returns the Application for this configuration identifying the asset produced by scala.js through webpack stats
       */
     def asApplicationBundle(stats: Option[WebpackStats]): ApplicationBundle =
       ApplicationBundle(project,
-                        targetDir
-                          .resolve(stats.flatMap(_.assetName(project))
-                            .fold(ApplicationBundle.fileName(project))(identity))
-                          .toFile,
-                        stats.map(_.assets.map(a => targetDir.resolve(a.name).toFile)).getOrElse(Nil))
-
+                        stats.flatMap { s =>
+                          s.resolveAsset(targetDir, project)
+                        }.getOrElse(targetDir.resolve(ApplicationBundle.fileName(project)).toFile),
+                        stats.map{ s =>
+                          s.resolveAllAssets(targetDir)
+                        }.getOrElse(Nil))
   }
 
   /**
@@ -123,6 +126,7 @@ object BundlerFile {
                           .resolve(ApplicationBundle.fileName(project))
                           .toFile,
                         assets)
+
   }
 
   /**

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
@@ -46,3 +46,19 @@ InputKey[Unit]("html") := {
     client.close()
   }
 }
+
+// Check that a HTML can be loaded on the output path specified
+InputKey[Unit]("htmlProd") := {
+  import complete.DefaultParsers._
+  import scala.sys.process._
+
+  val page = (Space ~> StringBasic).parsed
+  import com.gargoylesoftware.htmlunit.WebClient
+  val client = new WebClient()
+  try {
+    val demoDir = s"${new File((baseDirectory in Compile).value, "demo").absolutePath}"
+    client.getPage(s"file://$demoDir/$page")
+  } finally {
+    client.close()
+  }
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
@@ -27,9 +27,9 @@ webpackDevServerPort := 7357
 
 useYarn := true
 
-version in webpack                     := "4.6.0"
+version in webpack                     := "4.8.1"
 
-version in startWebpackDevServer       := "3.1.3"
+version in startWebpackDevServer       := "3.1.4"
 
 // Check that a HTML can be loaded (and that its JavaScript can be executed) without errors
 InputKey[Unit]("html") := {

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/prod.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/prod.config.js
@@ -2,10 +2,14 @@ const ScalaJS = require("./scalajs.webpack.config");
 const Merge = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
+const path = require("path");
+const rootDir = path.resolve(__dirname, "../../../..");
+
 const WebApp = Merge(ScalaJS, {
   mode: "production",
   output: {
-    filename: "app.js"
+    filename: "app.js",
+    path: path.resolve(rootDir, "demo")
   },
   plugins: [new HtmlWebpackPlugin()]
 });

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
@@ -5,7 +5,7 @@
 
 # Now let's try optimized
 > fullOptJS::webpack
-> html index.html
+> htmlProd index.html
 
 # Error case 1
 > set webpackConfigFile in fastOptJS := Some(new File("badconfig1.js"))


### PR DESCRIPTION
In hindsight, this is fairly obvious. By default, the plugin uses `targetDir` for the location of the output, but that can be modified in `webpack` with `output.path`.

This PR will read `outputPath` when possible and use it as the location of the published files