### PR TITLE
Better error display when the webpack call fails

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
@@ -66,9 +66,6 @@ object Stats {
         log.info(l.show)
       }
       log.info("")
-      // Filtering is a workaround for #111
-      warnings.filterNot(_.contains("https://raw.githubusercontent.com")).foreach(x => log.warn(x))
-      errors.foreach(x => log.error(x))
     }
 
     /**

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
@@ -259,7 +259,14 @@ object Webpack {
             case (p, v) => logger.error(s"$p: ${v.mkString(",")}")
           }
           None
-        case JsSuccess(p, _) => Some(p)
+        case JsSuccess(p, _) =>
+          if (p.warnings.nonEmpty || p.errors.nonEmpty) {
+            logger.info("")
+            // Filtering is a workaround for #111
+            p.warnings.filterNot(_.contains("https://raw.githubusercontent.com")).foreach(x => logger.warn(x))
+            p.errors.foreach(x => logger.error(x))
+          }
+          Some(p)
       }
     } match {
       case Success(x) =>

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/badconfig2.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/badconfig2.js
@@ -1,0 +1,24 @@
+const ScalaJS = require("./scalajs.webpack.config");
+const Merge = require("webpack-merge");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const path = require("path");
+const rootDir = path.resolve(__dirname, "../../../..");
+const resourcesDir = path.resolve(rootDir, "src/main/resources");
+
+const WebApp = Merge(ScalaJS, {
+  mode: "development",
+  entry: {
+    app: [path.resolve(resourcesDir, "./entry.js")]
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: ["style-loader"] // We should include css-loader
+      }
+    ]
+  },
+  plugins: [new HtmlWebpackPlugin()]
+});
+
+module.exports = WebApp;

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
@@ -23,6 +23,10 @@ npmDevDependencies in Compile += "html-webpack-plugin" -> "3.0.6"
 
 npmDevDependencies in Compile += "webpack-merge" -> "4.1.2"
 
+npmDevDependencies in Compile += "style-loader" -> "0.21.0"
+
+npmDevDependencies in Compile += "css-loader" -> "0.28.11"
+
 webpackDevServerPort := 7357
 
 useYarn := true

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/src/main/resources/entry.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/src/main/resources/entry.js
@@ -1,0 +1,1 @@
+import "./styles.css";

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/src/main/resources/styles.css
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/src/main/resources/styles.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
@@ -11,3 +11,8 @@
 > set webpackConfigFile in fastOptJS := Some(new File("badconfig1.js"))
 > clean
 -> fastOptJS::webpack
+
+# Error case 2
+> set webpackConfigFile in fastOptJS := Some(new File("badconfig2.js"))
+> clean
+-> fastOptJS::webpack


### PR DESCRIPTION
In case the call to webpack fails but the output is parseable the errors aren't displayed properly making debugging much harder.

This PR changes the location to print the errors and includes an example of a configuration that fails to demonstrate that errors are displayed anyway