### PR TITLE
Assets to sbt

### DIFF
--- a/manual/src/ornate/cookbook.md
+++ b/manual/src/ornate/cookbook.md
@@ -303,12 +303,25 @@ In particular, don't attempt to override the `--config` param.
 
 `scalajs-bundler` (version 0.12.0 onwards) supports webpack 4. To enable webpack 4, set the correct versions in `build.sbt`
 
--~~~ scala
+~~~ scala
 version in webpack := "4.8.1"
 
 version in startWebpackDevServer := "3.1.4"
--~~~
+~~~
 
 Additionally, you need to update any webpack plugins your config uses, to Webpack 4 compatible versions.
 
 Webpack 4 has the potential to substantially reduce your webpack compilation times (80% reductions have been observed but your mileage may vary)
+
+## How to use get a list of assets
+
+`scalajs-bundler` (version 0.13.0 onwards) will export a list of all assets preduced by webpack. You can read that list on sbt
+
+~~~ scala
+val files = (webpack in (Compile, fullOptJS)).value
+~~~
+
+You can use it e.g. with `[sbt-native-packager](https://github.com/sbt/sbt-native-packager)` to add mappings as:
+~~~ scala
+mappings in (Compile, packageBin) ++= (webpack in (Compile, fullOptJS)).value.map { f => f.data -> f.data.getName() },
+~~~

--- a/sbt-scalajs-bundler/src/main/scala-sbt-0.13/scala/scalajsbundler/util/CachedBundleFiles.scala
+++ b/sbt-scalajs-bundler/src/main/scala-sbt-0.13/scala/scalajsbundler/util/CachedBundleFiles.scala
@@ -1,0 +1,18 @@
+package scalajsbundler.util
+
+import java.io.File
+import scala.collection.immutable.ListSet
+
+object CachedBundleFiles {
+  /**
+   * Returns a "sorted" list of files containing first the main file
+   * and then the rest of the assets. While weak this convention lets us
+   * work around the design of sbt file caching
+   */
+  def cached(file: File, assets: List[File]): ListSet[File] = {
+    // Let's put the main file first
+    val sortedAssets = file :: assets.filterNot(_ == file)
+    // use list set to preserve the order. In sbt 0.13 we need to reverse the order
+    ListSet(sortedAssets.reverse: _*)
+  }
+}

--- a/sbt-scalajs-bundler/src/main/scala-sbt-1.0/scala/scalajsbundler/util/CachedBundleFiles.scala
+++ b/sbt-scalajs-bundler/src/main/scala-sbt-1.0/scala/scalajsbundler/util/CachedBundleFiles.scala
@@ -1,0 +1,13 @@
+package scalajsbundler.util
+
+import java.io.File
+import scala.collection.immutable.ListSet
+
+object CachedBundleFiles {
+  def cached(file: File, assets: List[File]): ListSet[File] = {
+    // Let's put the main file first
+    val sortedAssets = file :: assets.filterNot(_ == file)
+    // use list set to preserve the order
+    ListSet(sortedAssets: _*)
+  }
+}

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/BundlerFileType.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/BundlerFileType.scala
@@ -27,4 +27,9 @@ object BundlerFileType {
     * Fully linked application bundle, containing [[Application]] and all it's dependencies
     */
   case object ApplicationBundle extends BundlerFileType
+
+  /**
+    * An asset of the bundled application
+    */
+  case object Asset extends BundlerFileType
 }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
@@ -85,7 +85,7 @@ object Stats {
      * Resolve alles asset on the output path or the target dir if unavailable
      */
     def resolveAllAssets(altDir: Path): List[File] =
-      assets.flatMap(a => resolveAsset(altDir, a.name))
+      assets.map(a => outputPath.getOrElse(altDir).resolve(a.name).toFile)
   }
 
   implicit val assetsReads: Reads[Asset] = (

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/SBTBundlerFile.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/SBTBundlerFile.scala
@@ -12,11 +12,19 @@ import scalajsbundler.{BundlerFile, BundlerFileType}
 class SBTBundlerFile(f: BundlerFile.Public) {
     import SBTBundlerFile._
 
-    def asAttributedFile: sbt.Attributed[sbt.File] =
-      Attributed
-        .blank(f.file)
+    def asAttributedFiles: Seq[sbt.Attributed[sbt.File]] = {
+      val main = Attributed
+        .blank(f.attributedFiles._1)
         .put(ProjectNameAttr, f.project)
         .put(BundlerFileTypeAttr, f.`type`)
+      val assets = Attributed
+        .blankSeq(f.attributedFiles._2).map {
+          _
+          .put(ProjectNameAttr, f.project)
+          .put(BundlerFileTypeAttr, BundlerFileType.Asset)
+        }
+      main +: assets
+    }
 }
 
 object SBTBundlerFile {

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
@@ -37,20 +37,19 @@ object WebpackTasks {
           cacheLocation,
           inStyle = FilesInfo.hash
         ) { _ =>
-          Set(Webpack
-            .bundle(
-              emitSourceMaps,
-              generatedWebpackConfigFile,
-              customWebpackConfigFile,
-              webpackResourceFiles,
-              entriesList,
-              targetDir,
-              extraArgs,
-              webpackMode,
-              log
-            ).file)
+          Webpack.bundle(
+            emitSourceMaps,
+            generatedWebpackConfigFile,
+            customWebpackConfigFile,
+            webpackResourceFiles,
+            entriesList,
+            targetDir,
+            extraArgs,
+            webpackMode,
+            log
+          ).cached
         }
-      cachedActionFunction(monitoredFiles.to[Set])
-      Seq(generatedWebpackConfigFile.asApplicationBundle(None).asAttributedFile)
+      val cached = cachedActionFunction(monitoredFiles.to[Set])
+      generatedWebpackConfigFile.asApplicationBundleFromCached(cached).asAttributedFiles
     }
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/prod.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/prod.config.js
@@ -1,17 +1,30 @@
 const ScalaJS = require("./scalajs.webpack.config");
 const Merge = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 const path = require("path");
 const rootDir = path.resolve(__dirname, "../../../..");
+const resourcesDir = path.resolve(rootDir, "src/main/resources");
 
 const WebApp = Merge(ScalaJS, {
   mode: "production",
+  entry: {
+    app: [path.resolve(resourcesDir, "./entry.js")]
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: ["style-loader", MiniCssExtractPlugin.loader, "css-loader"]
+      }
+    ]
+  },
   output: {
-    filename: "app.js",
+    filename: "[name].[chunkhash].js",
     path: path.resolve(rootDir, "demo")
   },
-  plugins: [new HtmlWebpackPlugin()]
+  plugins: [new HtmlWebpackPlugin(), new MiniCssExtractPlugin({})]
 });
 
 module.exports = WebApp;

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
@@ -1,11 +1,12 @@
 # the server should properly start
 > fastOptJS::webpack
-> html index.html
+# 3 assets and 2 for loader and entry
+> html index.html 5
 > clean
 
 # Now let's try optimized
 > fullOptJS::webpack
-> htmlProd index.html
+> htmlProd index.html demo 7
 
 # Error case 1
 > set webpackConfigFile in fastOptJS := Some(new File("badconfig1.js"))


### PR DESCRIPTION
This is a feature I've been looking for to let more easily package applications processed with scala.js and webpack. It will export all the assets produced by webpack on

`(wepback in (Compile, full/fastOptJS))value`

With this change, I can e.g. package an application using sbt-native-packager and make it include all the files referred on the application, e.g. css, images, etc

This PR also lets me remove a few calls which were a bit strange like `.asApplicationBundle(None)` when we didn't have access to the `Stats`.

The test now includes a css that is referred from the entry point and that css and its map are now included in the list of assets.

I had to do one workaround to get this to work. `sbt` caches files using `FileFunction` as a `Set[File]` so we'd need to reconstruct the `Library` or `ApplicationBundle` objects from that list. I adopted the convention that the first item is the main `js` file and the rest are assets to make this work across the cache. It may be a bit weak but it should work in general and preserves the cache. I'm using `ListSet` to preserve the order.