### PR TITLE
Add npmInstall task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,10 @@ inScope(ThisScope.copy(project = Global))(List(
 
 lazy val commonSettings = ScriptedPlugin.scriptedSettings ++ List(
   runScripted := runScriptedTask.value,
-  scriptedLaunchOpts += "-Dplugin.version=" + version.value,
+  scriptedLaunchOpts ++= Seq(
+    "-Dplugin.version=" + version.value,
+    "-Dsbt.execute.extrachecks=true" // Avoid any deadlocks.
+  ),
   scriptedBufferLog := false,
   crossSbtVersions := List("0.13.17", "1.0.2"),
   scalaVersion := {

--- a/manual/src/ornate/changelog.md
+++ b/manual/src/ornate/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Version 0.13.2
+
+> 2018 Oct 27
+
+This release modifies the `npmUpdate` task and splits the logic into two separate tasks; `npmInstallDependencies` and
+`npmInstallJSResources`. `npmUpdate` has a less obvious side effect that, not only does it run `npm install`, it would
+also copy all the JavaScript resources to the `node_modules` directory. This behaviour is fine except that it is not
+suitable for use in `sourceGenerators` and would cause a cycle in the tasks. `npmInstallDependencies` should be used in
+cases where you want to want to use a npm module from a sbt task.
+
+This fixes the following bugs:
+
+- [#258](https://github.com/scalacenter/scalajs-bundler/issues/258): Unable to use npmUpdate in sourceGenerators
+
 ## Version 0.13.1
 
 > 2018 Jul 13

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -648,7 +648,6 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
           streams.value
         ),
 
-      crossTarget in npmUpdate := (crossTarget in npmUpdate).value,
 
       crossTarget in npmUpdate := {
         crossTarget.value / "scalajs-bundler" / (if (configuration.value == Compile) "main" else "test")

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/generated-sources/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/generated-sources/build.sbt
@@ -1,0 +1,6 @@
+enablePlugins(ScalaJSBundlerPlugin)
+
+sourceGenerators in Compile += Def.task {
+  val _ = (npmInstallDependencies in Compile).value
+  Seq.empty[File]
+}

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/generated-sources/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/generated-sources/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % sys.props.getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set")))

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/generated-sources/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/generated-sources/test
@@ -1,0 +1,3 @@
+# Tests that it is possible to use npm dev dependencies to generate sources
+# without creating a cycle in the tasks.
+> sources


### PR DESCRIPTION
This fixes #258.

I went with a more conservative approach which was to introduce a new task. We briefly discussed the removal of the staging of javascript resources from `npmUpdate` but this would have much more severe consequences for backwards compatibility.

I tested it out using https://github.com/scalacenter/scastie to make sure that the changes to `scalaJSBundlerPackageJson` to used `dependencyClasspath` didn't have any adverse affects. I first updated it to use `0.13.1` and generated the `package.json` and then updated to local build and there were no differences. I'm not sure if it is worth doing more thorough testing for this, it seems quite unlikely that change would have any negative impact, let me know what you think.