### PR TITLE
Define a custom setting to indicate DOM JsEnv in test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val `sbt-scalajs-bundler` =
       name := "sbt-scalajs-bundler",
       description := "Module bundler for Scala.js projects",
       libraryDependencies += "com.typesafe.play" %% "play-json" % "2.6.7",
-      addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+      addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
     )
 
 val `sbt-web-scalajs-bundler` =
@@ -26,7 +26,7 @@ val `sbt-web-scalajs-bundler` =
       },
       name := "sbt-web-scalajs-bundler",
       description := "Module bundler for Scala.js projects (integration with sbt-web-scalajs)",
-      addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.6")
+      addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.8-0.6")
     )
     .dependsOn(`sbt-scalajs-bundler`)
 

--- a/manual/src/ornate/changelog.md
+++ b/manual/src/ornate/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Version 0.14.0
+> Unreleased
+
+This fixes the following bugs:
+ - [#261](https://github.com/scalacenter/scalajs-bundler/issues/261): Support jsdom v12.x
+ - [#267](https://github.com/scalacenter/scalajs-bundler/issues/267): Support JDK9+
+ 
+New features:
+  - [#264](https://github.com/scalacenter/scalajs-bundler/issues/264): Ability to set `node` [flags](https://nodejs.org/api/cli.html)
+  - [#266](https://github.com/scalacenter/scalajs-bundler/issues/266): Custom setting for DOM enabled `JSEnv` in `test`. (`requiresDOM` is deprecated)
+
 ## Version 0.13.1
 
 > 2018 Jul 13

--- a/manual/src/ornate/reference.md
+++ b/manual/src/ornate/reference.md
@@ -44,7 +44,7 @@ your Scala facades (you can see an example
 If your tests execution environment require the DOM, add the following line to your build:
 
 ~~~ scala
-requiresDOM in Test := true
+requireJsDomEnv in Test := true
 ~~~
 
 Then, `ScalaJSBundlerPlugin` will automatically download jsdom and bundle the tests before

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -653,7 +653,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       npmDevDependencies ++= (npmDevDependencies in Compile).value,
 
       // Default to deprecated requiresDOM to not break old build.
-      requireJsDomEnv := (requiresDOM in Test).value,
+      requireJsDomEnv := requiresDOM.value,
 
       // Override Scala.js setting, which does not support the combination of jsdom and CommonJS module output kind
       loadedTestFrameworks := Def.task {

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -653,7 +653,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       npmDevDependencies ++= (npmDevDependencies in Compile).value,
 
       // Default to deprecated requiresDOM to not break old build.
-      requireJsDomEnv := (requiresDOM in Compile).value,
+      requireJsDomEnv := requiresDOM.?.value.getOrElse(false),
 
       // Override Scala.js setting, which does not support the combination of jsdom and CommonJS module output kind
       loadedTestFrameworks := Def.task {

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -568,7 +568,8 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       installDir
     },
 
-    requireJsDomEnv := false
+    // Default to deprecated requiresDOM to not break old build.
+    requireJsDomEnv := requiresDOM.value
   ) ++
     inConfig(Compile)(perConfigSettings) ++
     inConfig(Test)(perConfigSettings ++ testSettings)

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -653,7 +653,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       npmDevDependencies ++= (npmDevDependencies in Compile).value,
 
       // Default to deprecated requiresDOM to not break old build.
-      requireJsDomEnv := requiresDOM.value,
+      requireJsDomEnv := (requiresDOM in Compile).value,
 
       // Override Scala.js setting, which does not support the combination of jsdom and CommonJS module output kind
       loadedTestFrameworks := Def.task {

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -566,10 +566,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
         addPackages(baseDir, installDir, useYarn.value, log, npmExtraArgs.value, yarnExtraArgs.value)(s"jsdom@$jsdomVersion")
       }
       installDir
-    },
-
-    // Default to deprecated requiresDOM to not break old build.
-    requireJsDomEnv := requiresDOM.value
+    }
   ) ++
     inConfig(Compile)(perConfigSettings) ++
     inConfig(Test)(perConfigSettings ++ testSettings)
@@ -654,6 +651,9 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
       npmDependencies ++= (npmDependencies in Compile).value,
 
       npmDevDependencies ++= (npmDevDependencies in Compile).value,
+
+      // Default to deprecated requiresDOM to not break old build.
+      requireJsDomEnv := (requiresDOM in Test).value,
 
       // Override Scala.js setting, which does not support the combination of jsdom and CommonJS module output kind
       loadedTestFrameworks := Def.task {

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/custom-test-config/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/custom-test-config/build.sbt
@@ -21,7 +21,8 @@ webpackConfigFile in Test := Some(baseDirectory.value / "test.webpack.config.js"
 testFrameworks += new TestFramework("utest.runner.Framework")
 
 // Execute the tests in browser-like environment
-requireJsDomEnv in Test := true
+// Normally, the build should use requireJsDomEnv setting instead but old, deprecated requiresDOM should also work
+requiresDOM in Test := true
 
 webpackBundlingMode := BundlingMode.LibraryAndApplication()
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/custom-test-config/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/custom-test-config/build.sbt
@@ -21,7 +21,7 @@ webpackConfigFile in Test := Some(baseDirectory.value / "test.webpack.config.js"
 testFrameworks += new TestFramework("utest.runner.Framework")
 
 // Execute the tests in browser-like environment
-requiresDOM in Test := true
+requireJsDomEnv in Test := true
 
 webpackBundlingMode := BundlingMode.LibraryAndApplication()
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/build.sbt
@@ -25,7 +25,7 @@ webpackConfigFile in fastOptJS := Some(baseDirectory.value / "dev.webpack.config
 webpackConfigFile in Test := Some(baseDirectory.value / "test.webpack.config.js")
 
 // Execute the tests in browser-like environment
-requiresDOM in Test := true
+requireJsDomEnv in Test := true
 //#relevant-settings
 
 version in installJsdom := "12.0.0"

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
@@ -35,7 +35,7 @@ webpackConfigFile in Test := Some(baseDirectory.value / "common.webpack.config.j
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test
 
 // Execute the tests in browser-like environment
-requiresDOM in Test := true
+requireJsDomEnv in Test := true
 
 webpackBundlingMode := BundlingMode.LibraryAndApplication()
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
@@ -22,7 +22,7 @@ webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.confi
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test
 
 // Execute the tests in browser-like environment
-requiresDOM in Test := true
+requireJsDomEnv in Test := true
 
 useYarn := true
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
@@ -18,7 +18,7 @@ webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.confi
 libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test
 
 // Execute the tests in browser-like environment
-requiresDOM in Test := true
+requireJsDomEnv in Test := true
 
 webpackBundlingMode := BundlingMode.LibraryAndApplication()
 


### PR DESCRIPTION
should allow us to get rid of the already deprecated `requiresDOM` setting in scala.js.

should address #181