### PR TITLE
Update docs

### DIFF
--- a/manual/src/ornate/reference.md
+++ b/manual/src/ornate/reference.md
@@ -186,9 +186,11 @@ as sbt-web assets as follows:
 
 ~~~ scala
 npmAssets ++= NpmAssets.ofProject(client) { nodeModules =>
-  (nodeModules / "font-awesome").***
+  (nodeModules / "font-awesome").allPaths // sbt 1.0.0+
 }.value
 ~~~
+
+> Note: for older sbt versions use `(nodeModules / "font-awesome").***` instead.
 
 Where `client` is the identifier of an sbt project that uses the `ScalaJSBundlerPlugin`. The above configuration
 makes all the files within the `font-awesome` package available as sbt-web assets.


### PR DESCRIPTION
In [sbt 1.0.0 release](https://www.scala-sbt.org/1.x/docs/sbt-1.0-Release-Notes.html#sbt+1.0.0) the PathFinder's `***` method has been renamed to `allPaths`.

Using outdated code from the example will yield `error: value *** is not a member of java.io.File`.