### PR TITLE
Check scalaJSRequestsDOM to support depreacted RuntimeDOM usage

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -721,7 +721,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
       // Default to deprecated scalaJSRequestsDOM to not break old builds.
       // i.e. `requiresDOM := true` or `jsDependencies += RuntimeDOM`
-      requireJsDomEnv := scalaJSRequestsDOM.?.value.getOrElse(false),
+      requireJsDomEnv := scalaJSRequestsDOM.value,
 
       // Override Scala.js setting, which does not support the combination of jsdom and CommonJS module output kind
       loadedTestFrameworks := Def.task {

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -719,8 +719,9 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
       jsSourceDirectories ++= (jsSourceDirectories in Compile).value,
 
-      // Default to deprecated requiresDOM to not break old build.
-      requireJsDomEnv := requiresDOM.?.value.getOrElse(false),
+      // Default to deprecated scalaJSRequestsDOM to not break old builds.
+      // i.e. `requiresDOM := true` or `jsDependencies += RuntimeDOM`
+      requireJsDomEnv := scalaJSRequestsDOM.?.value.getOrElse(false),
 
       // Override Scala.js setting, which does not support the combination of jsdom and CommonJS module output kind
       loadedTestFrameworks := Def.task {


### PR DESCRIPTION
While we check `requireJsDomEnv` and deprecated `requiresDOM` to know if the build needs jsdom, ScalaJS 0.6.x also provides another way to declare jsdom dependency: `jsDependencies += RuntimeDOM`

> **Scala.js 0.6.x**: If your application or one of its libraries requires a DOM (which can be specified with `jsDependencies += RuntimeDOM`), the `JSDOMNodeJSEnv` environment described will be used by default.
>
> https://www.scala-js.org/doc/project/js-environments.html

So this patch recover `jsDependencies += RuntimeDOM` support as well as `requiresDOM`, by using `scalaJSRequestsDOM` which we used before.