### PR TITLE
Don't enable ScalaJSWeb

### DIFF
--- a/manual/src/ornate/getting-started.md
+++ b/manual/src/ornate/getting-started.md
@@ -66,7 +66,7 @@ lazy val client = project.enablePlugins(ScalaJSBundlerPlugin)
 
 You also need to setup the `ScalaJSBundlerPlugin` on the Scala.js project, as described in the preceding section, and
 the `sbt-web-scalajs` plugins as described in [their documentation](https://github.com/vmunier/sbt-web-scalajs).
-Note that `sbt-web-scalajs`'s `ScalaJSWeb` plugin must not be enabled, because `ScalaJSWeb` will create a source mapping to source files copied to a hash path, which conflicts with `ScalaJSBundlerPlugin`'s webpack-based source mapping.
+Note that `sbt-web-scalajs`'s `ScalaJSWeb` plugin must not be enabled, because `ScalaJSWeb` will create source mappings to source files copied to a hash path, which conflict with `ScalaJSBundlerPlugin`'s webpack-based source mappings.
 
 The `WebScalaJSBundlerPlugin` plugin automatically configures the `scalaJSPipeline` task to use
 the bundles rather than the output of the Scala.js compilation.

--- a/manual/src/ornate/getting-started.md
+++ b/manual/src/ornate/getting-started.md
@@ -66,6 +66,7 @@ lazy val client = project.enablePlugins(ScalaJSBundlerPlugin)
 
 You also need to setup the `ScalaJSBundlerPlugin` on the Scala.js project, as described in the preceding section, and
 the `sbt-web-scalajs` plugins as described in [their documentation](https://github.com/vmunier/sbt-web-scalajs).
+Note that `sbt-web-scalajs`'s `ScalaJSWeb` plugin must not be enabled, because `ScalaJSWeb` will create a source mapping to source files copied to a hash path, which conflicts with `ScalaJSBundlerPlugin`'s webpack-based source mapping.
 
 The `WebScalaJSBundlerPlugin` plugin automatically configures the `scalaJSPipeline` task to use
 the bundles rather than the output of the Scala.js compilation.

--- a/manual/src/ornate/getting-started.md
+++ b/manual/src/ornate/getting-started.md
@@ -61,7 +61,7 @@ lazy val server = project
   )
   .enablePlugins(WebScalaJSBundlerPlugin)
 
-lazy val client = project.enablePlugins(ScalaJSBundlerPlugin, ScalaJSWeb)
+lazy val client = project.enablePlugins(ScalaJSBundlerPlugin)
 ~~~
 
 You also need to setup the `ScalaJSBundlerPlugin` on the Scala.js project, as described in the preceding section, and


### PR DESCRIPTION
`ScalaJSWeb` plug-in will create a source mapping to hash path source file (https://github.com/vmunier/sbt-web-scalajs/blob/1e48af8b505867e12cfcfd212cf4180c87c82ca9/src/main/scala/webscalajs/ScalaJSWeb.scala#L23). Unfortunately, the source file is copied to `target/web/public/main` instead of `client/target/scala-2.12/scalajs-bundler/main`, which is not accessible from "source-map-loader".

As a result, a warning of `NonErrorEmittedError` will be thrown by webpack.

We should disable `ScalaJSWeb` to avoid the warning.