### PR TITLE
[WIP] Add ES modules support

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala-sjs-0.6/scalajsbundler/sbtplugin/Settings.scala
+++ b/sbt-scalajs-bundler/src/main/scala-sjs-0.6/scalajsbundler/sbtplugin/Settings.scala
@@ -11,7 +11,7 @@ import org.scalajs.sbtplugin.ScalaJSPluginInternal.{scalaJSEnsureUnforked, scala
 import sbt.Keys.{loadedTestFrameworks, streams, testFrameworks, version}
 import sbt._
 import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.autoImport.{installJsdom, npmUpdate, requireJsDomEnv, webpack, webpackConfigFile, webpackNodeArgs, webpackResources}
-import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.{createdTestAdapters, ensureModuleKindIsCommonJSModule}
+import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.{createdTestAdapters, ensureModuleKindIsNotNoModule}
 import scalajsbundler.scalajs.compat.testing.TestAdapter
 import scalajsbundler.{JSDOMNodeJSEnv, JsDomTestEntries, NpmPackage, Webpack}
 
@@ -40,7 +40,7 @@ private[sbtplugin] object Settings {
           case other => sys.error(s"You need a ComJSEnv to test (found ${other.name})")
         }.getOrElse {
           Def.taskDyn[ComJSEnv] {
-            assert(ensureModuleKindIsCommonJSModule.value)
+            assert(ensureModuleKindIsNotNoModule.value)
             val sjsOutput = fastOptJS.value.data
             // If jsdom is going to be used, then we should bundle the test module into a file that exports the tests to the global namespace
             if (requireJsDomEnv.value) Def.task {

--- a/sbt-scalajs-bundler/src/main/scala-sjs-0.6/scalajsbundler/util/ScalaJSOutputAnalyzer.scala
+++ b/sbt-scalajs-bundler/src/main/scala-sjs-0.6/scalajsbundler/util/ScalaJSOutputAnalyzer.scala
@@ -44,8 +44,8 @@ object ScalaJSOutputAnalyzer {
       moduleInitializers: Seq[ModuleInitializer],
       logger: Logger
   ): LinkingUnit = {
-    require(linkerConfig.moduleKind == ModuleKind.CommonJSModule,
-            s"linkerConfig.moduleKind was ${linkerConfig.moduleKind}")
+    require(linkerConfig.moduleKind != ModuleKind.NoModule,
+            s"linkerConfig.moduleKind was ModuleKind.NoModule")
     val symbolRequirements = {
       val backend = new BasicLinkerBackend(linkerConfig.semantics,
                                            linkerConfig.esFeatures,

--- a/sbt-scalajs-bundler/src/main/scala-sjs-1.x/scalajsbundler/sbtplugin/Settings.scala
+++ b/sbt-scalajs-bundler/src/main/scala-sjs-1.x/scalajsbundler/sbtplugin/Settings.scala
@@ -12,7 +12,7 @@ import sbt._
 import sbt.testing.Framework
 import scalajsbundler.{JSDOMNodeJSEnv, Webpack, JsDomTestEntries, NpmPackage}
 import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.autoImport.{installJsdom, npmUpdate, requireJsDomEnv, webpackConfigFile, webpackNodeArgs, webpackResources, webpack}
-import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.{createdTestAdapters, ensureModuleKindIsCommonJSModule}
+import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.{createdTestAdapters, ensureModuleKindIsNotNoModule}
 import scalajsbundler.scalajs.compat.io.FileVirtualBinaryFile
 import scalajsbundler.scalajs.compat.testing.TestAdapter
 
@@ -27,7 +27,7 @@ private[sbtplugin] object Settings {
     loadedTestFrameworks := Def.task {
       val (env, input) = {
         Def.taskDyn[(JSEnv, org.scalajs.jsenv.Input)] {
-          assert(ensureModuleKindIsCommonJSModule.value)
+          assert(ensureModuleKindIsNotNoModule.value)
           val sjsOutput = fastOptJS.value.data
           // If jsdom is going to be used, then we should bundle the test module into a file that exports the tests to the global namespace
           if (requireJsDomEnv.value) Def.task {

--- a/sbt-scalajs-bundler/src/main/scala-sjs-1.x/scalajsbundler/util/ScalaJSOutputAnalyzer.scala
+++ b/sbt-scalajs-bundler/src/main/scala-sjs-1.x/scalajsbundler/util/ScalaJSOutputAnalyzer.scala
@@ -50,8 +50,8 @@ object ScalaJSOutputAnalyzer {
   ): LinkingUnit = {
     import scala.concurrent.ExecutionContext.Implicits.global
 
-    require(linkerConfig.moduleKind == ModuleKind.CommonJSModule,
-            s"linkerConfig.moduleKind was ${linkerConfig.moduleKind}")
+    require(linkerConfig.moduleKind != ModuleKind.NoModule,
+            s"linkerConfig.moduleKind was ModuleKind.NoModule")
     val frontend = StandardLinkerFrontend(linkerConfig)
     val backend = new StoreLinkingUnitLinkerBackend(linkerConfig)
     val linker = StandardLinkerImpl(frontend, backend)

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
@@ -62,7 +62,7 @@ object LibraryTasks {
       stage: TaskKey[Attributed[File]],
       mode: BundlingMode.Library): Def.Initialize[Task[BundlerFile.Library]] =
     Def.task {
-      assert(ensureModuleKindIsCommonJSModule.value)
+      assert(ensureModuleKindIsNotNoModule.value)
       val log = streams.value.log
       val emitSourceMaps = (finallyEmitSourceMaps in stage).value
       val customWebpackConfigFile = (webpackConfigFile in stage).value
@@ -107,7 +107,7 @@ object LibraryTasks {
       stage: TaskKey[Attributed[File]],
       mode: BundlingMode.Library): Def.Initialize[Task[BundlerFile.Loader]] =
     Def.task {
-      assert(ensureModuleKindIsCommonJSModule.value)
+      assert(ensureModuleKindIsNotNoModule.value)
       val entry = WebpackTasks.entry(stage).value
       val loaderFile = entry.asLoader
 
@@ -122,7 +122,7 @@ object LibraryTasks {
                                    mode: BundlingMode.LibraryAndApplication)
     : Def.Initialize[Task[Seq[BundlerFile.Public]]] =
     Def.task {
-      assert(ensureModuleKindIsCommonJSModule.value)
+      assert(ensureModuleKindIsNotNoModule.value)
       val cacheLocation = streams.value.cacheDirectory / s"${stage.key.label}-webpack-bundle-all"
       val targetDir = npmUpdate.value
       val entry = WebpackTasks.entry(stage).value

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -537,10 +537,10 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
     KeyRanks.Invisible
   )
 
-  private[scalajsbundler] val ensureModuleKindIsCommonJSModule =
+  private[scalajsbundler] val ensureModuleKindIsNotNoModule =
     SettingKey[Boolean](
-      "ensureModuleKindIsCommonJSModule",
-      "Checks that scalaJSModuleKind is set to CommonJSModule",
+      "ensureModuleKindIsNotNoModule",
+      "Checks that scalaJSModuleKind is not set to NoModule",
       KeyRanks.Invisible
     )
 
@@ -567,9 +567,9 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
     useYarn := false,
 
-    ensureModuleKindIsCommonJSModule := {
-      if (scalaJSLinkerConfig.value.moduleKind == ModuleKind.CommonJSModule) true
-      else sys.error(s"scalaJSModuleKind must be set to ModuleKind.CommonJSModule in projects where ScalaJSBundler plugin is enabled")
+    ensureModuleKindIsNotNoModule := {
+      if (scalaJSLinkerConfig.value.moduleKind != ModuleKind.NoModule) true
+      else sys.error(s"scalaJSModuleKind must not be set to ModuleKind.NoModule in projects where ScalaJSBundler plugin is enabled")
     },
 
     webpackBundlingMode := BundlingMode.Default,

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
@@ -18,7 +18,7 @@ object WebpackTasks {
   private[sbtplugin] def webpack(
       stage: TaskKey[Attributed[File]]): Def.Initialize[Task[Seq[Attributed[File]]]] =
     Def.task {
-      assert(ensureModuleKindIsCommonJSModule.value)
+      assert(ensureModuleKindIsNotNoModule.value)
       val cacheLocation = streams.value.cacheDirectory / s"${stage.key.label}-webpack"
       val generatedWebpackConfigFile =
         (scalaJSBundlerWebpackConfig in stage).value


### PR DESCRIPTION
Fixes https://github.com/scalacenter/scalajs-bundler/issues/293

Allow to use ES modules as well as CommonJS module.

**WIP**: `BundlingMode.LibraryOnly()` does not work yet as with:
```html
<script src="[name]-fastopt-library.js"></script>
<script src="[name]-fastopt-loader.js"></script>
<script src="[name]-fastopt.js"></script>
```
the browser will not recognize the `import` syntax in the last script.

Adding the attribute `type="module"` is not enough: if `[name]-fastopt.js` contains something like `import * as $i_jquery from "jquery";` then the following error is thrown:
```
Uncaught TypeError: Failed to resolve module specifier "jquery". Relative references must start with either "/", "./", or "../".
```