### PR TITLE
Replace ScalaTest by JUnit in all Scala.js test projects.

### DIFF
--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/browserless/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/browserless/build.sbt
@@ -1,6 +1,6 @@
 name := "browserless"
 
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
 
 scalaVersion := "2.11.12"
 
@@ -8,8 +8,5 @@ scalaJSUseMainModuleInitializer := true
 
 // Adds a dependency on the uuid npm package
 npmDependencies in Compile += "uuid" -> "3.1.0"
-
-// Adds a dependency on scalatest
-libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0" % Test
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/browserless/src/test/scala/example/FooTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/browserless/src/test/scala/example/FooTest.scala
@@ -1,15 +1,12 @@
 package example
 
-import org.scalatest.FreeSpec
+import org.junit.Assert._
+import org.junit.Test
 
-class FooTest extends FreeSpec {
+class FooTest {
 
-  "Foo" - {
-
-    "has a bar method" in {
-      assert(Foo.bar() != null)
-    }
-
+  @Test def bar(): Unit = {
+    assertNotNull(Foo.bar())
   }
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/build.sbt
@@ -1,13 +1,11 @@
 name := "facade-examples"
 
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
 
 scalaVersion := "2.11.12"
 
 scalaJSUseMainModuleInitializer := true
 
 npmDependencies in Compile += "uuid" -> "3.1.0"
-
-libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0" % Test
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/src/test/scala/example/FacadesTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade-examples/src/test/scala/example/FacadesTest.scala
@@ -1,40 +1,26 @@
 package example
 
-import org.scalatest.FreeSpec
+import org.junit.Assert._
+import org.junit.Test
 
-class FacadesTest extends FreeSpec {
+class FacadesTest {
 
-  "Obj" - {
-
-    "has a bar method" in {
-      assert(Obj.bar(41) == 42)
-    }
-
+  @Test def testObj(): Unit = {
+    assertEquals(42, Obj.bar(41))
   }
 
-  "Func" - {
-
-    "acts as a function" in {
-      assert(Func(2, 5) == "Konrad says 2 plus 5 is 7")
-    }
-
+  @Test def testFunc(): Unit = {
+    assertEquals("Konrad says 2 plus 5 is 7", Func(2, 5))
   }
 
-  "Member" - {
-
-    "can be called as a function" in {
-      assert(Member(41) == 42)
-    }
-
+  @Test def testMember(): Unit = {
+    assertEquals(42, Member(41))
   }
 
-  "User" - {
-
-    "can be constructed and fields can be accessed" in {
-      val user = new User("Julien", 30)
-      assert(user.name == "Julien" && user.age == 30)
-    }
-
+  @Test def testUser(): Unit = {
+    val user = new User("Julien", 30)
+    assertEquals("Julien", user.name)
+    assertEquals(30, user.age)
   }
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade/build.sbt
@@ -4,11 +4,10 @@ val `facade-project` =
 
 lazy val usage =
   project.in(file("usage"))
-    .enablePlugins(ScalaJSBundlerPlugin)
+    .enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
     .settings(commonSettings: _*)
     .settings(
-      scalaJSUseMainModuleInitializer := true,
-      libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0" % Test
+      scalaJSUseMainModuleInitializer := true
     )
     .dependsOn(facade)
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade/usage/src/test/scala/example/FooTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/facade/usage/src/test/scala/example/FooTest.scala
@@ -1,15 +1,12 @@
 package example
 
-import org.scalatest.FreeSpec
+import org.junit.Assert._
+import org.junit.Test
 
-class FooTest extends FreeSpec {
+class FooTest {
 
-  "Foo" - {
-
-    "has a bar method" in {
-      assert(Foo.bar() != null)
-    }
-
+  @Test def bar(): Unit = {
+    assertNotNull(Foo.bar())
   }
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing_sjs-0.6/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing_sjs-0.6/build.sbt
@@ -1,7 +1,7 @@
 
 name := "global-namespace-with-jsdom-unit-testing"
 
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
 
 scalaVersion := "2.11.12"
 
@@ -29,8 +29,6 @@ requireJsDomEnv in Test := true
 //#relevant-settings
 
 version in installJsdom := "12.0.0"
-
-libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % Test
 
 useYarn := true
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing_sjs-0.6/src/test/scala/example/MainTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing_sjs-0.6/src/test/scala/example/MainTest.scala
@@ -1,20 +1,19 @@
 package example
 
-import org.scalatest.FreeSpec
+import org.junit.Assert._
+import org.junit.Test
 
 import scala.scalajs.js
 import scala.scalajs.js.Date
 
-class MainTest extends FreeSpec {
+class MainTest {
 
-  "getMillis" - {
-    "should return UNIX timestamp" in {
-      val millisBefore = Date.now().toLong
-      val millis = Main.getNowInMillis
-      val millisAfter = Date.now().toLong
-      assert(millis >= millisBefore)
-      assert(millis <= millisAfter)
-    }
+  @Test def getMillis(): Unit = {
+    val millisBefore = Date.now().toLong
+    val millis = Main.getNowInMillis
+    val millisAfter = Date.now().toLong
+    assertTrue(millis >= millisBefore)
+    assertTrue(millis <= millisAfter)
   }
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/js-resources/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/js-resources/build.sbt
@@ -1,13 +1,11 @@
 name := "js-resources"
 
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
 
 scalaVersion := "2.11.12"
 
 scalaJSUseMainModuleInitializer := true
 
 npmDependencies in Compile += "uuid" -> "3.1.0"
-
-libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0" % Test
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/js-resources/src/test/scala/example/MyModuleTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/js-resources/src/test/scala/example/MyModuleTest.scala
@@ -1,15 +1,12 @@
 package example
 
-import org.scalatest.FreeSpec
+import org.junit.Assert._
+import org.junit.Test
 
-class MyModuleTest extends FreeSpec {
+class MyModuleTest {
 
-  "MyModule" - {
-
-    "has a someUuid field" in {
-      assert(MyModule.someUuid != null)
-    }
-
+  @Test def someUuid(): Unit = {
+    assertNotNull(MyModule.someUuid)
   }
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/js-source-directory/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/js-source-directory/build.sbt
@@ -1,13 +1,11 @@
 name := "js-resources"
 
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
 
 scalaVersion := "2.11.12"
 
 scalaJSUseMainModuleInitializer := true
 
 npmDependencies in Compile += "uuid" -> "3.1.0"
-
-libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0" % Test
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/js-source-directory/src/test/scala/example/MyModuleTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/js-source-directory/src/test/scala/example/MyModuleTest.scala
@@ -1,22 +1,20 @@
 package example
 
-import org.scalatest.FreeSpec
+import org.junit.Assert._
+import org.junit.Test
 
-class MyModuleTest extends FreeSpec {
+class MyModuleTest {
 
-  "MyModule" - {
+  @Test def someUuid(): Unit = {
+    assertNotNull(MyModule.someUuid)
+  }
 
-    "has a someUuid field" in {
-      assert(MyModule.someUuid != null)
-    }
+  @Test def someConfig(): Unit = {
+    assertNotNull(MyModule.someConfig)
+  }
 
-    "has a someConfig field" in {
-      assert(MyModule.someConfig != null)
-    }
-
-    "has a someNestedConfig field" in {
-      assert(MyModule.someNestedConfig != null)
-    }
+  @Test def someNestedConfig(): Unit = {
+    assertNotNull(MyModule.someNestedConfig)
   }
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sbt-0.13.x/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sbt-0.13.x/build.sbt
@@ -1,7 +1,6 @@
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
 scalaVersion := "2.11.12"
 scalaJSUseMainModuleInitializer := true
 npmDependencies in Compile += "left-pad" -> "1.1.3"
-libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0" % Test
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sbt-0.13.x/src/test/scala/example/MainTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sbt-0.13.x/src/test/scala/example/MainTest.scala
@@ -1,31 +1,19 @@
 package example
 
-import org.scalatest.FreeSpec
+import org.junit.Assert._
+import org.junit.Test
 
-class MainTest extends FreeSpec {
+class MainTest {
 
-  "LeftPad" - {
-    "leftPad" in {
-      assert(LeftPad("123", 5) == "  123")
-    }
-
-    "leftPad with custom char" in {
-      assert(LeftPad("123", 5, '0') == "00123")
-    }
-
-    "leftPad with smaller length" in {
-      assert(LeftPad("123", 2) == "123")
-    }
+  @Test def leftPad(): Unit = {
+    assertEquals("  123", LeftPad("123", 5))
+    assertEquals("00123", LeftPad("123", 5, '0'))
+    assertEquals("123", LeftPad("123", 2))
   }
 
-  "Main" - {
-    "format with default length" in {
-      assert(Main.format("scala") == "     scala")
-    }
-
-    "format with length" in {
-      assert(Main.format("scala", 6) == " scala")
-    }
+  @Test def main(): Unit = {
+    assertEquals("     scala", Main.format("scala"))
+    assertEquals(" scala", Main.format("scala", 6))
   }
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sbt-1.0.x/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sbt-1.0.x/build.sbt
@@ -1,7 +1,6 @@
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
 scalaVersion := "2.12.3"
 scalaJSUseMainModuleInitializer := true
 npmDependencies in Compile += "left-pad" -> "1.1.3"
-libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0" % Test
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sbt-1.0.x/src/test/scala/example/MainTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sbt-1.0.x/src/test/scala/example/MainTest.scala
@@ -1,31 +1,19 @@
 package example
 
-import org.scalatest.FreeSpec
+import org.junit.Assert._
+import org.junit.Test
 
-class MainTest extends FreeSpec {
+class MainTest {
 
-  "LeftPad" - {
-    "leftPad" in {
-      assert(LeftPad("123", 5) == "  123")
-    }
-
-    "leftPad with custom char" in {
-      assert(LeftPad("123", 5, '0') == "00123")
-    }
-
-    "leftPad with smaller length" in {
-      assert(LeftPad("123", 2) == "123")
-    }
+  @Test def leftPad(): Unit = {
+    assertEquals("  123", LeftPad("123", 5))
+    assertEquals("00123", LeftPad("123", 5, '0'))
+    assertEquals("123", LeftPad("123", 2))
   }
 
-  "Main" - {
-    "format with default length" in {
-      assert(Main.format("scala") == "     scala")
-    }
-
-    "format with length" in {
-      assert(Main.format("scala", 6) == " scala")
-    }
+  @Test def main(): Unit = {
+    assertEquals("     scala", Main.format("scala"))
+    assertEquals(" scala", Main.format("scala", 6))
   }
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
@@ -1,7 +1,7 @@
 
 name := "sharedconfig"
 
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
 
 scalaVersion := "2.11.12"
 
@@ -31,8 +31,6 @@ webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.confi
 
 // Use the shared Webpack configuration file for reload workflow and for running the tests
 webpackConfigFile in Test := Some(baseDirectory.value / "common.webpack.config.js")
-
-libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0" % Test
 
 // Execute the tests in browser-like environment
 requireJsDomEnv in Test := true

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/src/test/scala/example/SomeTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/src/test/scala/example/SomeTest.scala
@@ -1,21 +1,21 @@
 package example
 
-import org.scalatest.FreeSpec
+import org.junit.Assert._
+import org.junit.Test
+
 import org.scalajs.dom.document
 
 import scala.scalajs.js
 import leaflet.modules._
 
-class SomeTest extends FreeSpec {
+class SomeTest {
 
-  "leaflet" - {
-    "should return a zoomlevel" in {
-      val container = document.body.innerHTML = """<div id="container" />"""
+  @Test def leafletZoom(): Unit = {
+    val container = document.body.innerHTML = """<div id="container" />"""
 
-      val map = Leaflet.map("container").setView(js.Array(51.505f, -0.09f), 13)
-      val zoomlevel = map.getZoom()
-      assert(zoomlevel == 13)
-    }
+    val map = Leaflet.map("container").setView(js.Array(51.505f, -0.09f), 13)
+    val zoomlevel = map.getZoom()
+    assertEquals(13, zoomlevel)
   }
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
@@ -1,6 +1,6 @@
 name := "static"
 
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
 
 scalaVersion := "2.11.12"
 
@@ -18,8 +18,6 @@ npmDevDependencies in Compile += "uglifyjs-webpack-plugin" -> "0.4.3"
 
 // Use a different Webpack configuration file for production
 webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.config.js")
-
-libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0" % Test
 
 // Execute the tests in browser-like environment
 requireJsDomEnv in Test := true

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/src/test/scala/example/SomeTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/src/test/scala/example/SomeTest.scala
@@ -1,33 +1,31 @@
 package example
 
-import org.scalatest.FreeSpec
+import org.junit.Assert._
+import org.junit.Test
+
 import org.scalajs.dom.document
 
 import scala.scalajs.js
 
-class SomeTest extends FreeSpec {
+class SomeTest {
 
-  "snabbdom" - {
-    "should patch the DOM" in {
+  @Test def testSnabbdom(): Unit = {
+    import snabbdom.{snabbdom, h, modules}
+    val patch =
+      snabbdom.init(js.Array(
+        modules.props
+      ))
 
-      import snabbdom.{snabbdom, h, modules}
-      val patch =
-        snabbdom.init(js.Array(
-          modules.props
-        ))
+    val vnode = h("h1", "It works": js.Any)
 
-      val vnode = h("h1", "It works": js.Any)
+    val container = document.createElement("div")
+    document.body.appendChild(container)
 
-      val container = document.createElement("div")
-      document.body.appendChild(container)
+    patch(container, vnode)
 
-      patch(container, vnode)
-
-      val patchedNode = document.body.lastChild
-      assert(patchedNode.nodeName == "H1")
-      assert(patchedNode.textContent == "It works")
-
-    }
+    val patchedNode = document.body.lastChild
+    assertEquals("H1", patchedNode.nodeName)
+    assertEquals("It works", patchedNode.textContent)
   }
 
 }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
@@ -1,6 +1,6 @@
 name := "static"
 
-enablePlugins(ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
 
 scalaVersion := "2.11.12"
 
@@ -14,8 +14,6 @@ npmDevDependencies in Compile += "uglifyjs-webpack-plugin" -> "1.2.2"
 
 // Use a different Webpack configuration file for production
 webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.config.js")
-
-libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0" % Test
 
 // Execute the tests in browser-like environment
 requireJsDomEnv in Test := true

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/src/test/scala/example/SomeTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/src/test/scala/example/SomeTest.scala
@@ -1,33 +1,31 @@
 package example
 
-import org.scalatest.FreeSpec
+import org.junit.Assert._
+import org.junit.Test
+
 import org.scalajs.dom.document
 
 import scala.scalajs.js
 
-class SomeTest extends FreeSpec {
+class SomeTest {
 
-  "snabbdom" - {
-    "should patch the DOM" in {
+  @Test def testSnabbdom(): Unit = {
+    import snabbdom.{snabbdom, h, modules}
+    val patch =
+      snabbdom.init(js.Array(
+        modules.props
+      ))
 
-      import snabbdom.{snabbdom, h, modules}
-      val patch =
-        snabbdom.init(js.Array(
-          modules.props
-        ))
+    val vnode = h("h1", "It works": js.Any)
 
-      val vnode = h("h1", "It works": js.Any)
+    val container = document.createElement("div")
+    document.body.appendChild(container)
 
-      val container = document.createElement("div")
-      document.body.appendChild(container)
+    patch(container, vnode)
 
-      patch(container, vnode)
-
-      val patchedNode = document.body.lastChild
-      assert(patchedNode.nodeName == "H1")
-      assert(patchedNode.textContent == "It works")
-
-    }
+    val patchedNode = document.body.lastChild
+    assertEquals("H1", patchedNode.nodeName)
+    assertEquals("It works", patchedNode.textContent)
   }
 
 }


### PR DESCRIPTION
This frees us from having to wait for ScalaTest to publish new releases compatible with Scala.js 1.x. Since the JUnit is provided by the core Scala.js team, it is guaranteed to be readily available. And given the trivial test suites used in the testing projects, using ScalaTest is not justified.