### PR TITLE
Copy directories in webpackResources

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
@@ -40,11 +40,14 @@ object Webpack {
     * @return The copied config file.
     */
   def copyCustomWebpackConfigFiles(targetDir: File, webpackResources: Seq[File])(customConfigFile: File): File = {
-    def copyToWorkingDir(targetDir: File)(file: File): File = {
-      val copy = targetDir / file.name
-      IO.copyFile(file, copy)
-      copy
-    }
+    def copyToWorkingDir(targetDir: File)(file: File): File =
+      if (file.isDirectory) {
+        IO.copyDirectory(file, targetDir)
+        targetDir
+      } else {
+        IO.copyFile(file, targetDir / file.name)
+        targetDir / file.name
+      }
 
     webpackResources.foreach(copyToWorkingDir(targetDir))
     copyToWorkingDir(targetDir)(customConfigFile)


### PR DESCRIPTION
Hi,

I've been trying to do the following lately:
```scala
@js.native @JSImport("./images/logo.svg", JSImport.Default)
object LogoSvg extends js.Object
```
I have the image in `src/main/resources/images/logo.svg`.

*build.sbt*:
```scala
Compile / npmDevDependencies += "file-loader" -> "5.0.2"
webpackConfigFile := Some(baseDirectory.value / "webpack.config.js")
webpackResources := webpackResources.value +++ PathFinder((Compile / resourceDirectory).value)
```

*webpack.config.js*:
```javascript
var webpack = require('webpack');

module.exports = require('./scalajs.webpack.config');

module.exports.module.rules.push({
  "test": new RegExp("\\.(png|svg|jpg|gif)$"),
  "use": ["file-loader"]
});
```

And this code change.

Thanks