### PR TITLE
Scala.js 1.x: configure jsEnv{,Input} instead of loadedTestFrameworks.

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala-sjs-0.6/scalajsbundler/scalajs/compat.scala
+++ b/sbt-scalajs-bundler/src/main/scala-sjs-0.6/scalajsbundler/scalajs/compat.scala
@@ -22,9 +22,4 @@ private[scalajsbundler] object compat {
     type Config = org.scalajs.core.tools.linker.StandardLinker.Config
   }
 
-  object testing {
-    type TestAdapter = org.scalajs.testadapter.TestAdapter
-    val TestAdapter = org.scalajs.testadapter.TestAdapter
-  }
-
 }

--- a/sbt-scalajs-bundler/src/main/scala-sjs-1.x/scalajsbundler/sbtplugin/Settings.scala
+++ b/sbt-scalajs-bundler/src/main/scala-sjs-1.x/scalajsbundler/sbtplugin/Settings.scala
@@ -1,23 +1,17 @@
 package scalajsbundler.sbtplugin
 
-import scala.annotation.tailrec
-
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import scala.collection.JavaConverters._
-import org.scalajs.jsenv.JSEnv
-import org.scalajs.linker.interface.{ModuleKind => _, _}
+import org.scalajs.linker.interface._
 import org.scalajs.sbtplugin._
-import org.scalajs.sbtplugin.Loggers.sbtLogger2ToolsLogger
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 import sbt.Keys._
 import sbt._
-import sbt.testing.Framework
 import scalajsbundler.{JSDOMNodeJSEnv, Webpack, JsDomTestEntries, NpmPackage}
 import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.autoImport.{installJsdom, npmUpdate, requireJsDomEnv, webpackConfigFile, webpackNodeArgs, webpackResources, webpack}
-import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.{createdTestAdapters, ensureModuleKindIsCommonJSModule, scalaJSBundlerImportedModules}
+import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.{ensureModuleKindIsCommonJSModule, scalaJSBundlerImportedModules}
 import scalajsbundler.sbtplugin.internal.BuildInfo
-import scalajsbundler.scalajs.compat.testing.TestAdapter
 
 private[sbtplugin] object Settings {
 
@@ -110,13 +104,33 @@ private[sbtplugin] object Settings {
   // Settings that must be applied in the Test configuration
   val testConfigSettings: Seq[Setting[_]] =
     Def.settings(
-      // Override loadedTestFrameworks from Scala.js, which does not support the combination of jsdom and CommonJS module output kind
-      loadedTestFrameworks := Def.task {
-        val (env, input) = {
-          Def.taskDyn[(JSEnv, Seq[org.scalajs.jsenv.Input])] {
-            assert(ensureModuleKindIsCommonJSModule.value)
-            val sjsOutput = fastOptJS.value.data
-            // If jsdom is going to be used, then we should bundle the test module into a file that exports the tests to the global namespace
+      // Configure a JSDOMNodeJSEnv with an installation of jsdom if requireJsDomEnv is true
+      jsEnv := {
+        val defaultJSEnv = jsEnv.value
+        val optJsdomDir = Def.taskDyn[Option[File]] {
+          if (requireJsDomEnv.value)
+            installJsdom.map(Some(_))
+          else
+            Def.task(None)
+        }.value
+        optJsdomDir match {
+          case Some(jsdomDir) => new JSDOMNodeJSEnv(JSDOMNodeJSEnv.Config(jsdomDir))
+          case None           => defaultJSEnv
+        }
+      },
+
+      // Use the product of bundling in jsEnvInput if requireJsDomEnv is true
+      jsEnvInput := Def.task {
+        import org.scalajs.jsenv.Input._
+
+        assert(ensureModuleKindIsCommonJSModule.value)
+        val prev = jsEnvInput.value
+        val sjsOutput = scalaJSLinkedFile.value.data
+
+        val optBundle = {
+          Def.taskDyn[Option[org.scalajs.jsenv.Input]] {
+            val sjsOutput = scalaJSLinkedFile.value.data
+            // If jsdom is going to be used, then we should bundle the test module
             if (requireJsDomEnv.value) Def.task {
               val logger = streams.value.log
               val targetDir = npmUpdate.value
@@ -160,56 +174,27 @@ private[sbtplugin] object Settings {
                 }
               writeTestBundleFunction(Set(sjsOutput))
 
-              val jsdomDir = installJsdom.value
-              val env = new JSDOMNodeJSEnv(JSDOMNodeJSEnv.Config(jsdomDir))
-              val input = List(org.scalajs.jsenv.Input.Script(bundle.toPath))
-              (env, input)
+              Some(Script(bundle.toPath))
             } else Def.task {
-              (jsEnv.value, jsEnvInput.value)
+              None
             }
           }.value
         }
 
-        val configName = configuration.value.name
-
-        if (fork.value) {
-          throw new MessageOnlyException(
-            s"`test in $configName` tasks in a Scala.js project require " +
-              s"`fork in $configName := false`.")
+        optBundle match {
+          case Some(bundle) =>
+            prev.map { inputItem =>
+              inputItem match {
+                case CommonJSModule(module) if module == sjsOutput.toPath() =>
+                  bundle
+                case _ =>
+                  inputItem
+              }
+            }
+          case None =>
+            prev
         }
-
-        if (!scalaJSUseTestModuleInitializer.value) {
-          throw new MessageOnlyException(
-            s"You may only use `test in $configName` tasks in " +
-              "a Scala.js project if `scalaJSUseTestModuleInitializer in " +
-              s"$configName := true`")
-        }
-
-        val frameworks = testFrameworks.value
-        val frameworkNames = frameworks.map(_.implClassNames.toList).toList
-
-        val logger = sbtLogger2ToolsLogger(streams.value.log)
-        val config = TestAdapter.Config()
-          .withLogger(logger)
-
-        val adapter = newTestAdapter(env, input, config)
-        val frameworkAdapters = adapter.loadFrameworks(frameworkNames)
-
-        frameworks.zip(frameworkAdapters).collect {
-          case (tf, Some(adapter)) => (tf, adapter)
-        }.toMap: Map[TestFramework, Framework]
       }.dependsOn(npmUpdate).value
     )
-
-  @tailrec
-  private def newTestAdapter(jsEnv: JSEnv, input: Seq[org.scalajs.jsenv.Input], config: TestAdapter.Config): TestAdapter = {
-    val prev = createdTestAdapters.get()
-    val r = new TestAdapter(jsEnv, input, config)
-    if (createdTestAdapters.compareAndSet(prev, r :: prev)) r
-    else {
-      r.close()
-      newTestAdapter(jsEnv, input, config)
-    }
-  }
 
 }

--- a/sbt-scalajs-bundler/src/main/scala-sjs-1.x/scalajsbundler/scalajs/compat.scala
+++ b/sbt-scalajs-bundler/src/main/scala-sjs-1.x/scalajsbundler/scalajs/compat.scala
@@ -26,8 +26,4 @@ private[scalajsbundler] object compat {
     type Config = org.scalajs.linker.interface.StandardConfig
   }
 
-  object testing {
-    type TestAdapter = org.scalajs.testing.adapter.TestAdapter
-    val TestAdapter = org.scalajs.testing.adapter.TestAdapter
-  }
 }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -1,7 +1,5 @@
 package scalajsbundler.sbtplugin
 
-import java.util.concurrent.atomic.AtomicReference
-
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 import org.scalajs.sbtplugin.{ScalaJSPlugin, Stage}
 import sbt.Keys._
@@ -10,7 +8,6 @@ import scalajsbundler.{BundlerFile, NpmDependencies, Webpack, WebpackDevServer}
 
 import scalajsbundler.ExternalCommand.addPackages
 import scalajsbundler.util.{JSON, ScalaJSNativeLibraries}
-import scalajsbundler.scalajs.compat.testing.TestAdapter
 
 
 /**
@@ -683,23 +680,8 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
     perScalaJSStageSettings(Stage.FastOpt) ++
     perScalaJSStageSettings(Stage.FullOpt)
 
-  private[scalajsbundler] val createdTestAdapters = new AtomicReference[List[TestAdapter]](Nil)
-
-  private def closeAllTestAdapters(): Unit =
-    createdTestAdapters.getAndSet(Nil).foreach(_.close())
-
-  override def globalSettings: Seq[Def.Setting[_]] = Def.settings(
-    onComplete := {
-      val prev = onComplete.value
-
-      { () =>
-        prev()
-        closeAllTestAdapters()
-      }
-    },
-
+  override def globalSettings: Seq[Def.Setting[_]] =
     Settings.globalSettings
-  )
 
   private lazy val testSettings: Seq[Setting[_]] =
     Def.settings(


### PR DESCRIPTION
We take advantage of the simpler pair of `jsEnv` and `jsEnvInput`, available in Scala.js 1.x, to implement the requirements of `requireJsDomEnv`, instead of duplicating logic from sbt-scalajs (including some low-level aspects involving `TestAdapter`s that are tricky to get right).

---

Now that the 1.x Settings do not create their own TestAdapters, they do not need the infrastructure. We move it from the settings that apply to both 0.6.x and 1.x to the 0.6.x-only Settings. This allows to remove the mentions to `TestAdapter` in the `compat` objects.