### PR TITLE
Upgrade to sbt 1.3.8 and use Scala.js 1.x by default.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,9 @@ environment:
   matrix:
     - CI_SBT_VERSION: 0.13.17
       SCALAJS_VERSION: 0.6.31
-    - CI_SBT_VERSION: 1.2.1
+    - CI_SBT_VERSION: 1.2.8
       SCALAJS_VERSION: 0.6.31
-    - CI_SBT_VERSION: 1.2.1
+    - CI_SBT_VERSION: 1.2.8
       SCALAJS_VERSION: 1.0.0
 install:
   - ps: Install-Product node 12

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.17
+sbt.version = 1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,10 @@
-resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
-
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
-
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-site"     % "1.1.0")
-addSbtPlugin("com.novocode"      % "sbt-ornate"   % "0.5")
-addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"   % "0.3.3")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"  % "0.5.4")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "2.3")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "2.0.0")
+addSbtPlugin("com.dwijnand"      % "sbt-dynver"    % "2.0.0")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-site"      % "1.4.0")
+addSbtPlugin("com.novocode"      % "sbt-ornate"    % "0.6")
+addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"    % "0.4.2")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"   % "0.6.3")
 addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo" % "0.7.0")
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet


### PR DESCRIPTION
Upgrading to sbt 1.x required upgrading all sbt plugins.

Using Scala.js 1.x by default provides a better experience in Metals out of the box, because of the `scalajs-bundler-linker` project which cannot resolve with Scala.js 0.6.x.

The sbt plugin is still compiled against sbt 1.2.8, so that users of sbt-scalajs-bundler are not forced to upgrade to sbt 1.3.x themselves.