### PR TITLE
Test only one configuration in AppVeyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,15 +2,11 @@ version: '{build}'
 os: Windows Server 2012
 environment:
   matrix:
-    - CI_SBT_VERSION: 0.13.17
-      SCALAJS_VERSION: 0.6.31
-    - CI_SBT_VERSION: 1.2.8
-      SCALAJS_VERSION: 0.6.31
     - CI_SBT_VERSION: 1.2.8
       SCALAJS_VERSION: 1.0.0
 install:
   - ps: Install-Product node 12
-  - cmd: choco install sbt --version 0.13.15 -ia "INSTALLDIR=""C:\sbt"""
+  - cmd: choco install sbt --version 1.2.8 -ia "INSTALLDIR=""C:\sbt"""
   - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g
 build: off


### PR DESCRIPTION
The free tier of AppVeyor never tests configurations in parallel. Since each configuration takes half an hour to test, running them all sequentially takes a very long time.

Since it is extremely unlikely that only one of the configurations would fail, only on Windows, we rely on the Linux builds to test the other configurations, and only test one of them on Windows.