### PR TITLE
Prepare next release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ env:
   - secure: CGqZrHZPgWOVZcjCL4iDJRlYPeC46Ko53ZufP4UtKpC7bdXgzqsbLVinI0EYwjZ0MZNUFQhOSKCK+2tNcnVA0EkhzMLSBE2sHXQ3fwO3EsoSGLCEOKh2LSrxb2S2AXHJer2/EsoJMCVyaYaQdWKWuK+CGLeTDJtP4l5Zeo1pF9kZOKDnaHHVmutnrbzcl39vsLOxFebaY5RP41irPKFV43bfUqfs5eoUslwt17QFLrXHQP7wlG9wzDwtqC2oonHO0GDWFs5NM2tju/J4FC31wFFslIEQ8Pabt8D4qGj+3rXt4KNiMM3v7G0kC1IYBEChVSrBcPMOljDWvMYYbqcAeIfLu/RsWGUX+e/e3FD6bbhoNIAAelYWqukPkvIFy4Y0iYjxFV6YZngiyuAgh+3+vwvhyQKh71hgVRxoVWFp3SXawj3mSnsDI6m4Dj9lO0lNG+eAEmFQfrmN2GC7OKhyT0/clazaYsdcKW2XsQN1qglWevepRtiOWO2vP6zBT8HHN8DV7YPLsZel3RMoqtkks5GWA0khu2yaWsCTz9i7RdPoFjdJdDJSgQG1Ta/1Dc6JuvgMOEJ3CQsZAMGZV9URu7m0m8iuLLOW5vglYQuIw5kjTgCF3r50QV5QgamLlrOkOUGd2DRv7jjFFBNpK9k0ndNCt7NEcKgbD8O8ne0UAp4=
   - secure: GRw7LuKilmu8IwGQo4G9UQUyG1IbVVewqlmEGxzdBj0hFwuPIc/hEfSS0g3CTA87iA+d960wsxwBpssu/e5sHk9RV5378W9MavGaTva8ifGNiMLn+lCEtA9sMr+eB+fTpdGh+PGqR9EDeeI6lMuuKGEUUDaxWAR198dP30DnfoZ4AHAV6QSyMHd2yPQa3lP+MPgZ8RnUok5ucEXSpkcwDpeptnl7WVirh6rIw9S6bJdN8eDKbapz+fXev3QECI8cJtU92AQAMnoQ9nkD4eI48yLg+EqXhTdZwls5lHLa1RW4XGhtt+26zOi/4/Mw/FoV5Nx6KszHO1nUq2AXCfXHINmZar9KmZt9ZCPL6Ap0/LXz6USrnz/EARHt08VMWXk4TXZu90ZYFglW/Tle1KEX6pV4hKvdrnDvqKlQvMBgm6fJvCIzbUtzeks5mhV1TWhm/l4UG0mBi4EqAjZsoM8QZ+cXMeiA+JQxLyE/a6Mf3ejWeqYsBfaOveRNiJID5tc+H2a1jwaDJq1lh78WYWqR8uq9husZas+VNVMwFAyt3w3ew/d3Z0kcmzOaujZC3OFmI20qd3+Aep9o32Qn1rCmRXmfD5IQFDx1OoR6bjfwDNoa2YDE/a9fH8MfFWqDam6C5PDOL0EPTe/PJUUY4Kk+6/x2Tm5bhQEXXt0RxZ23FBI=
   matrix:
-  - TRAVIS_SBT_VERSION="0.13.17"  SCALAJS_VERSION="0.6.31"
-  - TRAVIS_SBT_VERSION="1.2.8"    SCALAJS_VERSION="1.0.0"
-  - TRAVIS_SBT_VERSION="1.2.8"    SCALAJS_VERSION="0.6.31"
+  - TRAVIS_SBT_VERSION="0.13.17"  SCALAJS_VERSION="0.6.33"
+  - TRAVIS_SBT_VERSION="1.2.8"    SCALAJS_VERSION="1.1.0"
+  - TRAVIS_SBT_VERSION="1.2.8"    SCALAJS_VERSION="0.6.33"
 jdk:
   - openjdk11
 before_install:
@@ -26,7 +26,7 @@ script:
 - sbt -no-colors ";^^$TRAVIS_SBT_VERSION;test;runScripted"
 after_success:
 - if [ $TRAVIS_PULL_REQUEST = 'false' ] && [ -n "$TRAVIS_TAG" ]; then
-    if [ $TRAVIS_SBT_VERSION = '1.2.8' ] && [ $SCALAJS_VERSION = '1.0.0' ]; then
+    if [ $TRAVIS_SBT_VERSION = '1.2.8' ] && [ $SCALAJS_VERSION = '1.1.0' ]; then
       sbt scalajs-bundler-linker/publishSigned;
     fi;
     sbt ";^^$TRAVIS_SBT_VERSION; sbt-scalajs-bundler/publishSigned; sbt-web-scalajs-bundler/publishSigned; sonatypeReleaseAll; manual/makeSite; manual/ghpagesPushSite";

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - secure: GRw7LuKilmu8IwGQo4G9UQUyG1IbVVewqlmEGxzdBj0hFwuPIc/hEfSS0g3CTA87iA+d960wsxwBpssu/e5sHk9RV5378W9MavGaTva8ifGNiMLn+lCEtA9sMr+eB+fTpdGh+PGqR9EDeeI6lMuuKGEUUDaxWAR198dP30DnfoZ4AHAV6QSyMHd2yPQa3lP+MPgZ8RnUok5ucEXSpkcwDpeptnl7WVirh6rIw9S6bJdN8eDKbapz+fXev3QECI8cJtU92AQAMnoQ9nkD4eI48yLg+EqXhTdZwls5lHLa1RW4XGhtt+26zOi/4/Mw/FoV5Nx6KszHO1nUq2AXCfXHINmZar9KmZt9ZCPL6Ap0/LXz6USrnz/EARHt08VMWXk4TXZu90ZYFglW/Tle1KEX6pV4hKvdrnDvqKlQvMBgm6fJvCIzbUtzeks5mhV1TWhm/l4UG0mBi4EqAjZsoM8QZ+cXMeiA+JQxLyE/a6Mf3ejWeqYsBfaOveRNiJID5tc+H2a1jwaDJq1lh78WYWqR8uq9husZas+VNVMwFAyt3w3ew/d3Z0kcmzOaujZC3OFmI20qd3+Aep9o32Qn1rCmRXmfD5IQFDx1OoR6bjfwDNoa2YDE/a9fH8MfFWqDam6C5PDOL0EPTe/PJUUY4Kk+6/x2Tm5bhQEXXt0RxZ23FBI=
   matrix:
   - TRAVIS_SBT_VERSION="0.13.17"  SCALAJS_VERSION="0.6.33"
-  - TRAVIS_SBT_VERSION="1.2.8"    SCALAJS_VERSION="1.1.0"
+  - TRAVIS_SBT_VERSION="1.2.8"    SCALAJS_VERSION="1.0.0"
   - TRAVIS_SBT_VERSION="1.2.8"    SCALAJS_VERSION="0.6.33"
 jdk:
   - openjdk11
@@ -26,7 +26,7 @@ script:
 - sbt -no-colors ";^^$TRAVIS_SBT_VERSION;test;runScripted"
 after_success:
 - if [ $TRAVIS_PULL_REQUEST = 'false' ] && [ -n "$TRAVIS_TAG" ]; then
-    if [ $TRAVIS_SBT_VERSION = '1.2.8' ] && [ $SCALAJS_VERSION = '1.1.0' ]; then
+    if [ $TRAVIS_SBT_VERSION = '1.2.8' ] && [ $SCALAJS_VERSION = '1.0.0' ]; then
       sbt scalajs-bundler-linker/publishSigned;
     fi;
     sbt ";^^$TRAVIS_SBT_VERSION; sbt-scalajs-bundler/publishSigned; sbt-web-scalajs-bundler/publishSigned; sonatypeReleaseAll; manual/makeSite; manual/ghpagesPushSite";

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val runScripted = taskKey[Unit]("Run supported sbt scripted tests")
 
-val scalaJSVersion = sys.env.getOrElse("SCALAJS_VERSION", "1.1.0")
+val scalaJSVersion = sys.env.getOrElse("SCALAJS_VERSION", "1.0.0")
 val isScalaJS1x = scalaJSVersion.startsWith("1.")
 val scalaJSSourceDirectorySuffix = if (isScalaJS1x) "sjs-1.x" else "sjs-0.6"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val runScripted = taskKey[Unit]("Run supported sbt scripted tests")
 
-val scalaJSVersion = sys.env.getOrElse("SCALAJS_VERSION", "1.0.0")
+val scalaJSVersion = sys.env.getOrElse("SCALAJS_VERSION", "1.1.0")
 val isScalaJS1x = scalaJSVersion.startsWith("1.")
 val scalaJSSourceDirectorySuffix = if (isScalaJS1x) "sjs-1.x" else "sjs-0.6"
 
@@ -8,7 +8,7 @@ val scalaJSSourceDirectorySuffix = if (isScalaJS1x) "sjs-1.x" else "sjs-0.6"
 lazy val `scalajs-bundler-linker` =
   project.in(file("scalajs-bundler-linker"))
     .settings(
-      scalaVersion := "2.12.10",
+      scalaVersion := "2.12.11",
       libraryDependencies += "org.scala-js" %% "scalajs-linker" % scalaJSVersion
     )
 
@@ -89,7 +89,7 @@ val manual =
     .enablePlugins(OrnatePlugin, GhpagesPlugin)
     .settings(noPublishSettings: _*)
     .settings(
-      scalaVersion := "2.12.10",
+      scalaVersion := "2.12.11",
       git.remoteRepo := "git@github.com:scalacenter/scalajs-bundler.git",
       ornateSourceDir := Some(sourceDirectory.value / "ornate"),
       ornateTargetDir := Some(ornateTarget.value),
@@ -157,7 +157,7 @@ lazy val commonSettings = List(
   scalaVersion := {
     (sbtBinaryVersion in pluginCrossBuild).value match {
       case "0.13" => "2.10.7"
-      case _ => "2.12.10"
+      case _ => "2.12.11"
     }
   }
 )

--- a/manual/src/ornate/changelog.md
+++ b/manual/src/ornate/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.18.0
+
+> 2020 May 16
+
+This release adds support for scala.js 1.1.0
+
 ## Version 0.17.0
 
 > 2020 Feb 24

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/newer-linker_sjs-1/project/newer-scala-js.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/newer-linker_sjs-1/project/newer-scala-js.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.0")

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/newer-linker_sjs-1/src/test/scala/example/NewerLinkerTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/newer-linker_sjs-1/src/test/scala/example/NewerLinkerTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 class NewerLinkerTest {
 
   @Test def newerLinker(): Unit = {
-    assertEquals("1.0.1", System.getProperty("java.vm.version"))
+    assertEquals("1.1.0", System.getProperty("java.vm.version"))
 
     /* Test the fix to https://github.com/scala-js/scala-js/issues/3984, which
      * was shipped in Scala.js 1.0.1.

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static-webpack2/build.sbt
@@ -42,7 +42,7 @@ InputKey[Unit]("html") := {
 
 TaskKey[Unit]("checkSize") := {
   val artifactSize = IO.readBytes((webpack in (Compile, fullOptJS)).value.head.data).length
-  val sizeLow = 18000
+  val sizeLow = 16000
   val sizeHigh = 21000
   assert(
     artifactSize >= sizeLow && artifactSize <= sizeHigh,

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
@@ -49,7 +49,7 @@ TaskKey[Unit]("checkSize") := {
   //#filter-files
   val artifactSize = IO.readBytes(bundleFile).length
 
-  val sizeLow = 18000
+  val sizeLow = 17000
   val sizeHigh = 22000
 
   // Account for minor variance in size due to transitive dependency updates


### PR DESCRIPTION
This should get scalajs-bundler ready for the next release.
I tested it with a local publish and a project set to use scala.js 1.1.0