### PR TITLE
Update static test

### DIFF
--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
@@ -2,15 +2,13 @@ name := "static"
 
 enablePlugins(ScalaJSBundlerPlugin, ScalaJSJUnitPlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.13.3"
 
 scalaJSUseMainModuleInitializer := true
 
 libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.0.0"
 
 npmDependencies in Compile += "snabbdom" -> "0.5.3"
-
-npmDevDependencies in Compile += "uglifyjs-webpack-plugin" -> "1.2.2"
 
 // Use a different Webpack configuration file for production
 webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.config.js")
@@ -19,6 +17,8 @@ webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.confi
 requireJsDomEnv in Test := true
 
 version in installJsdom := "16.2.0"
+
+version in webpack := "4.44.1"
 
 webpackBundlingMode := BundlingMode.LibraryAndApplication()
 
@@ -50,7 +50,7 @@ TaskKey[Unit]("checkSize") := {
   val artifactSize = IO.readBytes(bundleFile).length
 
   val sizeLow = 17000
-  val sizeHigh = 22000
+  val sizeHigh = 29000
 
   // Account for minor variance in size due to transitive dependency updates
   assert(

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/index-prod.html
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/index-prod.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <div id="container"></div>
-    <script src="target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js"></script>
+    <script src="target/scala-2.13/scalajs-bundler/main/static-opt-bundle.js"></script>
   </body>
 </html>

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/index.html
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/index.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <div id="container"></div>
-    <script src="target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js"></script>
+    <script src="target/scala-2.13/scalajs-bundler/main/static-fastopt-bundle.js"></script>
   </body>
 </html>

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/prod.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/prod.webpack.config.js
@@ -1,7 +1,5 @@
-var UglifyJsPlugin = require("uglifyjs-webpack-plugin");
-
 module.exports = require("./scalajs.webpack.config");
 
-module.exports.plugins = (module.exports.plugins || []).concat([
-  new UglifyJsPlugin({ sourceMap: module.exports.devtool === "source-map" })
-]);
+module.exports.optimization = {
+  minimize: true,
+};

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/test
@@ -1,11 +1,11 @@
-$ absent target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js.map
+$ absent target/scala-2.13/scalajs-bundler/main/static-fastopt-bundle.js target/scala-2.13/scalajs-bundler/main/static-fastopt-bundle.js.map
 > fastOptJS::webpack
-$ exists target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js.map
+$ exists target/scala-2.13/scalajs-bundler/main/static-fastopt-bundle.js target/scala-2.13/scalajs-bundler/main/static-fastopt-bundle.js.map
 > html index.html
 
-$ absent target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js.map
+$ absent target/scala-2.13/scalajs-bundler/main/static-opt-bundle.js target/scala-2.13/scalajs-bundler/main/static-opt-bundle.js.map
 > fullOptJS::webpack
-$ exists target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js.map
+$ exists target/scala-2.13/scalajs-bundler/main/static-opt-bundle.js target/scala-2.13/scalajs-bundler/main/static-opt-bundle.js.map
 > html index-prod.html
 > checkSize
 
@@ -14,9 +14,9 @@ $ exists target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js target/scal
 > clean
 > set scalaJSLinkerConfig := scalaJSLinkerConfig.value.withSourceMap(false)
 > fastOptJS::webpack
-$ absent target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js.map
+$ absent target/scala-2.13/scalajs-bundler/main/static-fastopt-bundle.js.map
 > fullOptJS::webpack
-$ absent target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js.map
+$ absent target/scala-2.13/scalajs-bundler/main/static-opt-bundle.js.map
 
 # webpackEmitSourceMaps controls source maps emission for the webpack task
 
@@ -24,12 +24,12 @@ $ absent target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js.map
 > set scalaJSLinkerConfig := scalaJSLinkerConfig.value.withSourceMap(true)
 > set webpackEmitSourceMaps in (Compile, fastOptJS) := false
 > fastOptJS::webpack
-$ exists target/scala-2.11/scalajs-bundler/main/static-fastopt.js.map
-$ absent target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js.map
+$ exists target/scala-2.13/scalajs-bundler/main/static-fastopt.js.map
+$ absent target/scala-2.13/scalajs-bundler/main/static-fastopt-bundle.js.map
 
 > set webpackEmitSourceMaps in (Compile, fullOptJS) := false
 > fullOptJS::webpack
-$ exists target/scala-2.11/scalajs-bundler/main/static-opt.js.map
-$ absent target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js.map
+$ exists target/scala-2.13/scalajs-bundler/main/static-opt.js.map
+$ absent target/scala-2.13/scalajs-bundler/main/static-opt-bundle.js.map
 
 > test


### PR DESCRIPTION
Upgrade the `static` test. Updates scala to 2.13 and removes uglify since it is not needed with newer webpack versions