### PR TITLE
Remove obsolete warning regarding scalajs-scripts usage

### DIFF
--- a/manual/src/ornate/reference.md
+++ b/manual/src/ornate/reference.md
@@ -187,12 +187,6 @@ where you used to enable `WebScalaJS`).
 The plugin tunes the `scalaJSPipeline` to use the bundles produced by webpack rather than the direct
 output of the Scala.js compilation.
 
-> {.note}
-> The [scalajs-scripts](https://github.com/vmunier/scalajs-scripts) will **not** work anymore because they
-> try to include the output of Scala.js instead of the output of the bundling process. You can see
-> [here](https://github.com/scalacenter/scalajs-bundler/blob/master/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/server/src/main/scala/example/ExampleController.scala#L25-L30)
-> how to include the correct .js file.
-
 ### Importing Assets from NPM Packages {#npm-assets}
 
 Some NPM packages also contain static assets (e.g. fonts, stylesheets, images, etc.). You can make them available

--- a/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/build.sbt
+++ b/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/build.sbt
@@ -19,7 +19,10 @@ val server =
     .disablePlugins(PlayLayoutPlugin)
     .settings(
       scalaVersion := "2.13.2",
-      libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
+      libraryDependencies ++= Seq(
+        "com.vmunier" %% "scalajs-scripts" % "1.1.4",
+        "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
+      ),
       scalaJSProjects := Seq(client),
       pipelineStages in Assets := Seq(scalaJSPipeline),
       pipelineStages := Seq(digest, gzip),

--- a/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/server/src/main/scala/example/ExampleController.scala
+++ b/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/server/src/main/scala/example/ExampleController.scala
@@ -6,7 +6,6 @@ import play.twirl.api.StringInterpolation
 class ExampleController(cc: ControllerComponents) extends AbstractController(cc) {
 
   val index = {
-    val scriptUrl = bundleUrl("client")
     val result =
       Ok(
         html"""<!doctype html>
@@ -14,7 +13,7 @@ class ExampleController(cc: ControllerComponents) extends AbstractController(cc)
           <head></head>
           <body>
             <div>App is not loaded.</div>
-            <script src="$scriptUrl"></script>
+            @scalajs.html.scripts("client", routes.Assets.versioned(_).toString, name => getClass.getResource(s"/public/$$name") != null)
           </body>
         </html>
       """
@@ -22,10 +21,4 @@ class ExampleController(cc: ControllerComponents) extends AbstractController(cc)
     Action(result)
   }
 
-  def bundleUrl(projectName: String): Option[String] = {
-    val name = projectName.toLowerCase
-    Seq(s"$name-opt-bundle.js", s"$name-fastopt-bundle.js")
-      .find(name => getClass.getResource(s"/public/$name") != null)
-      .map(controllers.routes.Assets.versioned(_).url)
-  }
 }

--- a/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/server/src/main/scala/example/ExampleController.scala
+++ b/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/server/src/main/scala/example/ExampleController.scala
@@ -13,7 +13,7 @@ class ExampleController(cc: ControllerComponents) extends AbstractController(cc)
           <head></head>
           <body>
             <div>App is not loaded.</div>
-            @scalajs.html.scripts("client", routes.Assets.versioned(_).toString, name => getClass.getResource(s"/public/$$name") != null)
+            ${scalajs.html.scripts("client", controllers.routes.Assets.versioned(_).toString, name => getClass.getResource(s"/public/$name") != null)}
           </body>
         </html>
       """


### PR DESCRIPTION
 WebScalaJSBundlerPlugin works just fine with scalajs-scripts since [this update](https://github.com/vmunier/scalajs-scripts/blob/2a37ef7cde4ea6ce0f40e0d7318ea5f218f765f2/src/main/twirl/scalajs/selectScript.scala.html#L9).