### PR TITLE
Upgrade to Scala.js 1.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val scalaJSVersion = sys.env.getOrElse("SCALAJS_VERSION", "1.0.0")
+val scalaJSVersion = sys.env.getOrElse("SCALAJS_VERSION", "1.3.0")
 
 lazy val `scalajs-bundler-linker` =
   project.in(file("scalajs-bundler-linker"))

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/browserless/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/browserless/test
@@ -1,8 +1,9 @@
 > run
-> clean
 > test
-> set useYarn := true
-> clean
-> run
-> clean
-> test
+
+# Deactivated because `clean` followed by `run` kills the AppVeyor build.
+# Testing yarn support is done enough in other tests.
+#> set useYarn := true
+#> clean
+#> run
+#> test

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/newer-linker/project/newer-scala-js.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/newer-linker/project/newer-scala-js.sbt
@@ -1,1 +1,2 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.0")
+// TODO Set this to a version > 1.3.0 when there is one
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/newer-linker/src/test/scala/example/NewerLinkerTest.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/newer-linker/src/test/scala/example/NewerLinkerTest.scala
@@ -6,7 +6,10 @@ import org.junit.Test
 class NewerLinkerTest {
 
   @Test def newerLinker(): Unit = {
-    assertEquals("1.1.0", System.getProperty("java.vm.version"))
+    /* TODO Set this to a version > 1.3.0 when there is one, and adapt the
+     * test below to something that would have been fixed in the meantime.
+     */
+    assertEquals("1.3.0", System.getProperty("java.vm.version"))
 
     /* Test the fix to https://github.com/scala-js/scala-js/issues/3984, which
      * was shipped in Scala.js 1.0.1.

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/test
@@ -11,7 +11,7 @@ $ exists target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js target/scal
 
 # Disabling source maps in Scala.js also disables it for scalajs-bundler
 
-> clean
+$ delete target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js.map target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js.map
 > set scalaJSLinkerConfig := scalaJSLinkerConfig.value.withSourceMap(false)
 > fastOptJS::webpack
 $ absent target/scala-2.11/scalajs-bundler/main/static-fastopt-bundle.js.map
@@ -20,7 +20,6 @@ $ absent target/scala-2.11/scalajs-bundler/main/static-opt-bundle.js.map
 
 # webpackEmitSourceMaps controls source maps emission for the webpack task
 
-> clean
 > set scalaJSLinkerConfig := scalaJSLinkerConfig.value.withSourceMap(true)
 > set webpackEmitSourceMaps in (Compile, fastOptJS) := false
 > fastOptJS::webpack

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/yarn-interactive/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/yarn-interactive/build.sbt
@@ -4,6 +4,8 @@ useYarn := true
 
 yarnExtraArgs in Compile := Seq("--silent")
 
+scalaJSUseMainModuleInitializer := true
+
 npmDependencies in Compile += "neat" -> "1.1.2"
 
 enablePlugins(ScalaJSBundlerPlugin)

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/yarn-interactive/src/main/scala/example/Main.scala
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/yarn-interactive/src/main/scala/example/Main.scala
@@ -1,0 +1,7 @@
+package example
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("yarn-interactive main")
+  }
+}

--- a/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/test
+++ b/sbt-web-scalajs-bundler/src/sbt-test/sbt-web-scalajs-bundler/play/test
@@ -1,15 +1,14 @@
-> clean
 > server/assets
 $ exists client/target/scala-2.13/scalajs-bundler/main/client-fastopt-bundle.js
 $ absent client/target/scala-2.13/scalajs-bundler/main/client-opt-bundle.js
+$ delete client/target/scala-2.13/scalajs-bundler/main/client-fastopt-bundle.js
 
-> clean
 > set scalaJSStage in Global := FullOptStage
 > server/assets
 $ exists client/target/scala-2.13/scalajs-bundler/main/client-opt-bundle.js
 $ absent client/target/scala-2.13/scalajs-bundler/main/client-fastopt-bundle.js
+$ delete client/target/scala-2.13/scalajs-bundler/main/client-opt-bundle.js
 
-> clean
 > set scalaJSStage in Global := FastOptStage
 > server/test
 > client/test

--- a/scalajs-bundler-linker/src/main/scala/scalajsbundler/bundlerlinker/EntryPointAnalyzerBackend.scala
+++ b/scalajs-bundler-linker/src/main/scala/scalajsbundler/bundlerlinker/EntryPointAnalyzerBackend.scala
@@ -6,14 +6,12 @@ import scala.collection.JavaConverters._
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 
-import org.scalajs.ir.Trees.JSNativeLoadSpec
-
 import org.scalajs.logging.Logger
 
 import org.scalajs.linker.interface._
 import org.scalajs.linker.standard._
 
-final class EntryPointAnalyzerBackend(linkerConfig: StandardConfig, entryPointOutputFile: Path) extends LinkerBackend  {
+final class EntryPointAnalyzerBackend(linkerConfig: StandardConfig, entryPointOutputFile: Path) extends LinkerBackend {
   private val standard = StandardLinkerBackend(linkerConfig)
 
   val coreSpec: CoreSpec = standard.coreSpec
@@ -21,32 +19,10 @@ final class EntryPointAnalyzerBackend(linkerConfig: StandardConfig, entryPointOu
 
   def injectedIRFiles: Seq[IRFile] = standard.injectedIRFiles
 
-  def emit(unit: LinkingUnit, output: LinkerOutput, logger: Logger)(
-      implicit ec: ExecutionContext): Future[Unit] = {
-
-    val modules = importedModules(unit)
+  def emit(moduleSet: ModuleSet, output: OutputDirectory, logger: Logger)(
+      implicit ec: ExecutionContext): Future[Report] = {
+    val modules = moduleSet.modules.flatMap(_.externalDependencies).toSet
     Files.write(entryPointOutputFile, modules.toIterable.asJava, StandardCharsets.UTF_8)
-
-    standard.emit(unit, output, logger)
-  }
-
-  private def importedModules(linkingUnit: LinkingUnit): List[String] = {
-    if (linkerConfig.moduleKind == ModuleKind.NoModule) {
-      Nil
-    } else {
-      def importedModulesOf(loadSpec: JSNativeLoadSpec): List[String] = {
-        import JSNativeLoadSpec._
-        loadSpec match {
-          case Import(module, _)                              => List(module)
-          case ImportWithGlobalFallback(Import(module, _), _) => List(module)
-          case Global(_, _)                                   => Nil
-        }
-      }
-
-      linkingUnit.classDefs
-        .flatMap(_.jsNativeLoadSpec)
-        .flatMap(importedModulesOf(_))
-        .distinct
-    }
+    standard.emit(moduleSet, output, logger)
   }
 }


### PR DESCRIPTION
This commit contains the minimum amount of changes for scalajs-bundler to work with Scala.js 1.3.0. However, it still only works when module splitting is not actually used. To be precise, it still relies on the legacy keys `fastOptJS` and `fullOptJS`, and therefore on the fact that linking only produces one module.

Integrating with module splitting is left for future work.