### PR TITLE
Add support for Webpack 5 and drop previous versions

### DIFF
--- a/manual/src/ornate/cookbook.md
+++ b/manual/src/ornate/cookbook.md
@@ -287,7 +287,7 @@ webpackDevServerExtraArgs := Seq("--inline")
 `webpack` is then called with the following arguments:
 
 ~~~
---bail --config <configfile>
+--config <configfile>
 ~~~
 
 You can add extra params to the `webpack` call, for example, to increase debugging

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/PackageJson.scala
@@ -42,25 +42,18 @@ object PackageJson {
 
     val sourceMapLoaderVersion =
       NpmPackage(webpackVersion).major match {
-        case Some(1) | Some(2) => "0.1.5"
-        case Some(3)           => "0.2.1"
-        case Some(4)           => "0.2.3"
-        case Some(x)           => sys.error(s"Unsupported webpack major version $x")
-        case None              => sys.error("No webpack version defined")
-      }
-
-    val webpackPackages =
-      NpmPackage(webpackVersion).major match {
-        case Some(1) | Some(2) | Some(3) => Seq("webpack" -> webpackVersion)
-        case Some(4)                     => Seq("webpack" -> webpackVersion, "webpack-cli" -> webpackCliVersion)
-        case _                           => Seq.empty
+        case Some(5) => "2.0.0"
+        case Some(x) => sys.error(s"Unsupported webpack major version $x")
+        case None    => sys.error("No webpack version defined")
       }
 
     val devDependencies =
       npmDevDependencies ++ (
         if (currentConfiguration == Compile) npmManifestDependencies.compileDevDependencies
         else npmManifestDependencies.testDevDependencies
-      ) ++ webpackPackages ++ Seq(
+      ) ++ Seq(
+        "webpack" -> webpackVersion,
+        "webpack-cli" -> webpackCliVersion,
         "webpack-dev-server" -> webpackDevServerVersion,
         "concat-with-sourcemaps" -> "1.0.7", // Used by the reload workflow
         "source-map-loader" -> sourceMapLoaderVersion // Used by webpack when emitSourceMaps is enabled
@@ -77,7 +70,6 @@ object PackageJson {
 
     log.debug("Writing 'package.json'")
     IO.write(targetFile, packageJson.toJson)
-    ()
   }
 
   /**

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
@@ -13,7 +13,7 @@ import java.nio.file.Path
  */
 object Stats {
 
-  final case class Asset(name: String, size: Long, emitted: Option[Boolean], chunkNames: List[String]) {
+  final case class Asset(name: String, size: Long, emitted: Boolean, chunkNames: List[String]) {
     def formattedSize: String = {
       val oneKiB = 1024L
       val oneMiB = oneKiB * oneKiB
@@ -50,7 +50,19 @@ object Stats {
 
   }
 
-  final case class WebpackStats(version: String, hash: String, time: Long, outputPath: Option[Path], errors: List[String], warnings: List[String], assets: List[Asset]) {
+  final case class WebpackError(moduleName: String, message: String, loc: String)
+
+  final case class WebpackWarning(moduleName: String, message: String)
+
+  final case class WebpackStats(
+    version: String,
+    hash: String,
+    time: Long,
+    outputPath: Option[Path],
+    errors: List[WebpackError],
+    warnings: List[WebpackWarning],
+    assets: List[Asset]
+  ) {
 
     /**
       * Prints to the log an output similar to what webpack pushes to stdout
@@ -62,7 +74,7 @@ object Stats {
       log.info("")
       // Print the assets
       assets.map { a =>
-        val emitted = a.emitted.fold("<unknown>")(a => if (a) "[emitted]" else "")
+        val emitted = if (a.emitted) "[emitted]" else ""
         AssetLine(Part(a.name), Part(a.formattedSize), Part(emitted), Part(a.chunkNames.mkString("[", ",", "]")))
       }.foldLeft(List(AssetLine.Zero)) {
         case (lines, curr) =>
@@ -98,17 +110,28 @@ object Stats {
   implicit val assetsReads: Reads[Asset] = (
     (JsPath \ "name").read[String] and
     (JsPath \ "size").read[Long] and
-    (JsPath \ "emitted").readNullable[Boolean] and
-    (JsPath \\ "chunkNames").read[List[String]]
+    (JsPath \ "emitted").read[Boolean] and
+    (JsPath \ "chunkNames").read[List[String]]
   )(Asset.apply _)
+
+  implicit val errorReads: Reads[WebpackError] = (
+    (JsPath \ "moduleName").read[String] and
+      (JsPath \ "message").read[String] and
+      (JsPath \ "loc").read[String]
+    )(WebpackError.apply _)
+
+  implicit val warningReads: Reads[WebpackWarning] = (
+    (JsPath \ "moduleName").read[String] and
+      (JsPath \ "message").read[String]
+    )(WebpackWarning.apply _)
 
   implicit val statsReads: Reads[WebpackStats] = (
     (JsPath \ "version").read[String] and
     (JsPath \ "hash").read[String] and
     (JsPath \ "time").read[Long] and
     (JsPath \ "outputPath").readNullable[String].map(x => x.map(new File(_).toPath)) and // It seems webpack 2 doesn't produce outputPath
-    (JsPath \ "errors").read[List[String]] and
-    (JsPath \ "warnings").read[List[String]] and
+    (JsPath \ "errors").read[List[WebpackError]] and
+    (JsPath \ "warnings").read[List[WebpackWarning]] and
     (JsPath \ "assets").read[List[Asset]]
   )(WebpackStats.apply _)
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
@@ -243,8 +243,16 @@ object Webpack {
           if (p.warnings.nonEmpty || p.errors.nonEmpty) {
             logger.info("")
             // Filtering is a workaround for #111
-            p.warnings.filterNot(_.contains("https://raw.githubusercontent.com")).foreach(x => logger.warn(x))
-            p.errors.foreach(x => logger.error(x))
+            p.warnings.filterNot(_.message.contains("https://raw.githubusercontent.com")).foreach { warning =>
+              logger.warn(s"WARNING in ${warning.moduleName}")
+              logger.warn(warning.message)
+              logger.warn("\n")
+            }
+            p.errors.foreach { error =>
+              logger.error(s"ERROR in ${error.moduleName} ${error.loc}")
+              logger.error(error.message)
+              logger.error("\n")
+            }
           }
           Some(p)
       }
@@ -273,7 +281,7 @@ object Webpack {
     */
   def run(nodeArgs: String*)(args: String*)(workingDir: File, log: Logger): Option[WebpackStats] = {
     val webpackBin = workingDir / "node_modules" / "webpack" / "bin" / "webpack"
-    val params = nodeArgs ++ Seq(webpackBin.absolutePath, "--bail", "--profile", "--json") ++ args
+    val params = nodeArgs ++ Seq(webpackBin.absolutePath, "--profile", "--json") ++ args
     val cmd = "node" +: params
     Commands.run(cmd, workingDir, log, jsonOutput(cmd, log)).fold(sys.error, _.flatten)
   }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Webpack.scala
@@ -10,7 +10,7 @@ import Stats._
 import scala.util.{Failure, Success, Try}
 
 object Webpack {
-  // Represents webpack 4 modes
+  // Represents webpack 5 modes
   sealed trait WebpackMode {
     def mode: String
   }
@@ -61,95 +61,74 @@ object Webpack {
     webpackConfigFile: BundlerFile.WebpackConfig,
     libraryBundleName: Option[String],
     mode: WebpackMode,
+    devServerPort: Int,
     log: Logger
   ): Unit = {
-    log.info("Writing scalajs.webpack.config.js")
-    // Build the output configuration, configured for library output
-    // if a library bundle name is provided
-    val output = libraryBundleName match {
-      case Some(bundleName) =>
-        JS.obj(
-          "path" -> JS.str(webpackConfigFile.targetDir.toAbsolutePath.toString),
-          "filename" -> JS.str(BundlerFile.Library.fileName("[name]")),
-          "library" -> JS.str(bundleName),
-          "libraryTarget" -> JS.str("var")
-        )
-      case None =>
-        JS.obj(
-          "path" -> JS.str(webpackConfigFile.targetDir.toAbsolutePath.toString),
-          "filename" -> JS.str(BundlerFile.ApplicationBundle.fileName("[name]"))
-        )
-    }
+    val webpackConfigContent = generateConfigFile(emitSourceMaps, entry, webpackConfigFile, libraryBundleName, mode,
+      devServerPort)
 
-    // Build the file itself
-    val webpackConfigContent =
-      JS.ref("module").dot("exports").assign(JS.obj(Seq(
-        "entry" -> JS.obj(
-          entry.project -> JS.arr(JS.str(entry.file.absolutePath))
-        ),
-        "output" -> output
-      ) ++ (
-        if (emitSourceMaps) {
-          val webpackNpmPackage = NpmPackage.getForModule(webpackConfigFile.targetDir.toFile, "webpack")
-          webpackNpmPackage.flatMap(_.major) match {
-            case Some(1) =>
-              Seq(
-                "devtool" -> JS.str("source-map"),
-                "module" -> JS.obj(
-                  "preLoaders" -> JS.arr(
-                    JS.obj(
-                      "test" -> JS.regex("\\.js$"),
-                      "loader" -> JS.str("source-map-loader")
-                    )
-                  )
-                )
-              )
-            case Some(2) =>
-              Seq(
-                "devtool" -> JS.str("source-map"),
-                "module" -> JS.obj(
-                  "rules" -> JS.arr(
-                    JS.obj(
-                      "test" -> JS.regex("\\.js$"),
-                      "enforce" -> JS.str("pre"),
-                      "loader" -> JS.str("source-map-loader")
-                    )
-                  )
-                )
-              )
-            case Some(3) =>
-              Seq(
-                "devtool" -> JS.str("source-map"),
-                "module" -> JS.obj(
-                  "rules" -> JS.arr(
-                    JS.obj(
-                      "test" -> JS.regex("\\.js$"),
-                      "enforce" -> JS.str("pre"),
-                      "use" -> JS.arr(JS.str("source-map-loader"))
-                    )
-                  )
-                )
-              )
-            case Some(4) =>
-              Seq(
-                "mode" -> JS.str(mode.mode),
-                "devtool" -> JS.str("source-map"),
-                "module" -> JS.obj(
-                  "rules" -> JS.arr(
-                    JS.obj(
-                      "test" -> JS.regex("\\.js$"),
-                      "enforce" -> JS.str("pre"),
-                      "use" -> JS.arr(JS.str("source-map-loader"))
-                    )
-                  )
-                )
-              )
-            case Some(x) => sys.error(s"Unsupported webpack major version $x")
-            case None => sys.error("No webpack version defined")
-          }
-        } else Nil
-        ): _*))
+    log.info("Writing scalajs.webpack.config.js")
     IO.write(webpackConfigFile.file, webpackConfigContent.show)
+  }
+
+  private def generateConfigFile(
+    emitSourceMaps: Boolean,
+    entry: BundlerFile.WebpackInput,
+    webpackConfigFile: BundlerFile.WebpackConfig,
+    libraryBundleName: Option[String],
+    mode: WebpackMode,
+    devServerPort: Int
+  ): JS = {
+    val webpackNpmPackage = NpmPackage.getForModule(webpackConfigFile.targetDir.toFile, "webpack")
+    webpackNpmPackage.flatMap(_.major) match {
+      case Some(5) =>
+        // Build the output configuration, configured for library output
+        // if a library bundle name is provided
+        val output = libraryBundleName match {
+          case Some(bundleName) =>
+            JS.obj(
+              "path" -> JS.str(webpackConfigFile.targetDir.toAbsolutePath.toString),
+              "filename" -> JS.str(BundlerFile.Library.fileName("[name]")),
+              "library" -> JS.str(bundleName),
+              "libraryTarget" -> JS.str("var")
+            )
+          case None =>
+            JS.obj(
+              "path" -> JS.str(webpackConfigFile.targetDir.toAbsolutePath.toString),
+              "filename" -> JS.str(BundlerFile.ApplicationBundle.fileName("[name]"))
+            )
+        }
+
+        JS.ref("module").dot("exports").assign(JS.obj(Seq(
+          "entry" -> JS.obj(
+            entry.project -> JS.arr(JS.str(entry.file.absolutePath))
+          ),
+          "output" -> output,
+          "mode" -> JS.str(mode.mode),
+          "devServer" -> JS.obj("port" -> JS.int(devServerPort)),
+        ) ++ (
+          if (emitSourceMaps) {
+            Seq(
+              "devtool" -> JS.str("source-map"),
+              "module" -> JS.obj(
+                "rules" -> JS.arr(
+                  JS.obj(
+                    "test" -> JS.regex("\\.js$"),
+                    "enforce" -> JS.str("pre"),
+                    "use" -> JS.arr(JS.str("source-map-loader"))
+                  )
+                )
+              )
+            )
+          } else Nil
+          ): _*))
+
+      case Some(x) =>
+        sys.error(s"Unsupported webpack major version $x")
+
+      case None =>
+        sys.error("No webpack version defined")
+    }
   }
 
   /**
@@ -162,7 +141,8 @@ object Webpack {
     * @param entry Scala.js application to bundle
     * @param targetDir Target directory (and working directory for Nodejs)
     * @param extraArgs Extra arguments passed to webpack
-    * @param mode Mode for webpack 4
+    * @param mode Mode for webpack 5
+    * @param devServerPort Port used by webpack-dev-server
     * @param log Logger
     * @return The generated bundles
     */
@@ -176,9 +156,10 @@ object Webpack {
      extraArgs: Seq[String],
      nodeArgs: Seq[String],
      mode: WebpackMode,
+     devServerPort: Int,
      log: Logger
   ): BundlerFile.ApplicationBundle = {
-    writeConfigFile(emitSourceMaps, entry, generatedWebpackConfigFile, None, mode, log)
+    writeConfigFile(emitSourceMaps, entry, generatedWebpackConfigFile, None, mode, devServerPort, log)
 
     val configFile = customWebpackConfigFile
       .map(Webpack.copyCustomWebpackConfigFiles(targetDir, webpackResources))
@@ -206,7 +187,7 @@ object Webpack {
     * @param entryPointFile The entrypoint file to bundle dependencies for
     * @param libraryModuleName The library module name to assign the webpack bundle to
     * @param extraArgs Extra arguments passed to webpack
-    * @param mode Mode for webpack 4
+    * @param mode Mode for webpack 5
     * @param log Logger
     * @return The generated bundle
     */
@@ -220,6 +201,7 @@ object Webpack {
     extraArgs: Seq[String],
     nodeArgs: Seq[String],
     mode: WebpackMode,
+    devServerPort: Int,
     log: Logger
   ): BundlerFile.Library = {
     writeConfigFile(
@@ -228,6 +210,7 @@ object Webpack {
       generatedWebpackConfigFile,
       Some(libraryModuleName),
       mode,
+      devServerPort,
       log
     )
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/WebpackDevServer.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/WebpackDevServer.scala
@@ -13,7 +13,6 @@ private [scalajsbundler] class WebpackDevServer {
   /**
     * @param workDir - path to working directory for webpack-dev-server
     * @param configPath - path to webpack config.
-    * @param port - port, on which the server will operate.
     * @param extraArgs - additional arguments for webpack-dev-server.
     * @param logger - a logger to use for output
     * @param globalLogger - a global logger to use for output even when the task is terminated
@@ -21,7 +20,6 @@ private [scalajsbundler] class WebpackDevServer {
   def start(
     workDir: File,
     configPath: File,
-    port: Int,
     extraArgs: Seq[String],
     logger: Logger,
     globalLogger: Logger,
@@ -30,7 +28,6 @@ private [scalajsbundler] class WebpackDevServer {
     worker = Some(new Worker(
       workDir,
       configPath,
-      port,
       extraArgs,
       logger,
       globalLogger
@@ -47,7 +44,6 @@ private [scalajsbundler] class WebpackDevServer {
   private class Worker(
     workDir: File,
     configPath: File,
-    port: Int,
     extraArgs: Seq[String],
     logger: Logger,
     globalLogger: Logger,
@@ -56,11 +52,10 @@ private [scalajsbundler] class WebpackDevServer {
 
     val command = Seq(
       "node",
-      "node_modules/webpack-dev-server/bin/webpack-dev-server.js",
+      "node_modules/webpack/bin/webpack",
+      "serve",
       "--config",
-      configPath.getAbsolutePath,
-      "--port",
-      port.toString
+      configPath.getAbsolutePath
     ) ++ extraArgs
 
     val process = util.Commands.start(command, workDir, globalLogger)

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/LibraryTasks.scala
@@ -53,6 +53,7 @@ object LibraryTasks {
       val nodeArgs = (webpackNodeArgs in stage).value
       val webpackMode =
         Webpack.WebpackMode.fromBooleanProductionMode((scalaJSLinkerConfig in stage).value.semantics.productionMode)
+      val devServerPort = webpackDevServerPort.value
 
       val cachedActionFunction =
         FileFunction.cached(
@@ -71,6 +72,7 @@ object LibraryTasks {
             extraArgs,
             nodeArgs,
             webpackMode,
+            devServerPort,
             log
           ).cached
         }

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -553,11 +553,11 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
 
-    version in webpack := "5.12.0",
+    version in webpack := "5.24.3",
 
-    webpackCliVersion := "4.3.1",
+    webpackCliVersion := "4.5.0",
 
-    version in startWebpackDevServer := "3.11.1",
+    version in startWebpackDevServer := "3.11.2",
 
     version in installJsdom := "9.9.0",
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -553,11 +553,11 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
 
-    version in webpack := "4.32.2",
+    version in webpack := "5.12.0",
 
-    webpackCliVersion := "3.3.2",
+    webpackCliVersion := "4.3.1",
 
-    version in startWebpackDevServer := "3.4.1",
+    version in startWebpackDevServer := "3.11.1",
 
     version in installJsdom := "9.9.0",
 
@@ -764,7 +764,6 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
       // webpack-dev-server wiring
       startWebpackDevServer in stageTask := Def.task {
-        val port = (webpackDevServerPort in stageTask).value
         val extraArgs = (webpackDevServerExtraArgs in stageTask).value
 
         // This duplicates file layout logic from `Webpack`
@@ -787,7 +786,6 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
         server.start(
           workDir,
           config,
-          port,
           extraArgs,
           logger,
           globalLogger

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/Settings.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/Settings.scala
@@ -187,19 +187,23 @@ private[sbtplugin] object Settings {
                     case Some(configFile) =>
                       val customConfigFileCopy = Webpack.copyCustomWebpackConfigFiles(targetDir, webpackResources.value.get)(configFile)
                       NpmPackage(webpackVersion).major match {
-                        case Some(4) =>
+                        case Some(5) =>
                           // TODO: It assumes tests are run on development mode. It should instead use build settings
                           Webpack.run(nodeArgs: _*)("--mode", "development", "--config", customConfigFileCopy.getAbsolutePath, loader.absolutePath, "--output", bundle.absolutePath)(targetDir, logger)
-                        case _ =>
-                          Webpack.run(nodeArgs: _*)("--config", customConfigFileCopy.getAbsolutePath, loader.absolutePath, bundle.absolutePath)(targetDir, logger)
+                        case Some(x) =>
+                          sys.error(s"Unsupported webpack major version $x")
+                        case None =>
+                          sys.error("No webpack version defined")
                       }
                     case None =>
                       NpmPackage(webpackVersion).major match {
-                        case Some(4) =>
+                        case Some(5) =>
                           // TODO: It assumes tests are run on development mode. It should instead use build settings
                           Webpack.run(nodeArgs: _*)("--mode", "development", loader.absolutePath, "--output", bundle.absolutePath)(targetDir, logger)
-                        case _ =>
-                          Webpack.run(nodeArgs: _*)(loader.absolutePath, bundle.absolutePath)(targetDir, logger)
+                        case Some(x) =>
+                          sys.error(s"Unsupported webpack major version $x")
+                        case None =>
+                          sys.error("No webpack version defined")
                       }
                   }
 

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/Settings.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/Settings.scala
@@ -119,13 +119,11 @@ private[sbtplugin] object Settings {
         // Replace the path to the `main` module by the path to the legacy key output
         optMainModulePath match {
           case Some(mainModulePath) =>
-            prev.map { inputItem =>
-              inputItem match {
-                case CommonJSModule(module) if module == mainModulePath =>
-                  CommonJSModule(legacyKeyOutput.data.toPath())
-                case _ =>
-                  inputItem
-              }
+            prev.map {
+              case CommonJSModule(module) if module == mainModulePath =>
+                CommonJSModule(legacyKeyOutput.data.toPath())
+              case inputItem =>
+                inputItem
             }
           case None =>
             prev
@@ -183,28 +181,30 @@ private[sbtplugin] object Settings {
                   val loader = targetDir / s"$sjsOutputName-loader.js"
                   JsDomTestEntries.writeLoader(sjsOutput, loader)
 
-                  customWebpackConfigFile match {
+                  val configArgs = customWebpackConfigFile match {
                     case Some(configFile) =>
                       val customConfigFileCopy = Webpack.copyCustomWebpackConfigFiles(targetDir, webpackResources.value.get)(configFile)
-                      NpmPackage(webpackVersion).major match {
-                        case Some(5) =>
-                          // TODO: It assumes tests are run on development mode. It should instead use build settings
-                          Webpack.run(nodeArgs: _*)("--mode", "development", "--config", customConfigFileCopy.getAbsolutePath, loader.absolutePath, "--output", bundle.absolutePath)(targetDir, logger)
-                        case Some(x) =>
-                          sys.error(s"Unsupported webpack major version $x")
-                        case None =>
-                          sys.error("No webpack version defined")
-                      }
+                      Seq("--config", customConfigFileCopy.getAbsolutePath)
+
                     case None =>
-                      NpmPackage(webpackVersion).major match {
-                        case Some(5) =>
-                          // TODO: It assumes tests are run on development mode. It should instead use build settings
-                          Webpack.run(nodeArgs: _*)("--mode", "development", loader.absolutePath, "--output", bundle.absolutePath)(targetDir, logger)
-                        case Some(x) =>
-                          sys.error(s"Unsupported webpack major version $x")
-                        case None =>
-                          sys.error("No webpack version defined")
-                      }
+                      Seq.empty
+                  }
+
+                  // TODO: It assumes tests are run on development mode. It should instead use build settings
+                  val allArgs = Seq(
+                    "--mode", "development",
+                    "--entry", loader.absolutePath,
+                    "--output-path", bundle.getParentFile.absolutePath,
+                    "--output-filename", bundle.name
+                  ) ++ configArgs
+
+                  NpmPackage(webpackVersion).major match {
+                    case Some(5) =>
+                      Webpack.run(nodeArgs: _*)(allArgs: _*)(targetDir, logger)
+                    case Some(x) =>
+                      sys.error(s"Unsupported webpack major version $x")
+                    case None =>
+                      sys.error("No webpack version defined")
                   }
 
                   Set.empty
@@ -220,13 +220,11 @@ private[sbtplugin] object Settings {
 
         optBundle match {
           case Some(bundle) =>
-            prev.map { inputItem =>
-              inputItem match {
-                case CommonJSModule(module) if module == sjsOutput.toPath() =>
-                  bundle
-                case _ =>
-                  inputItem
-              }
+            prev.map {
+              case CommonJSModule(module) if module == sjsOutput.toPath() =>
+                bundle
+              case inputItem =>
+                inputItem
             }
           case None =>
             prev

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebpackTasks.scala
@@ -33,6 +33,7 @@ object WebpackTasks {
       val nodeArgs = (webpackNodeArgs in stage).value
       val webpackMode =
         Webpack.WebpackMode.fromBooleanProductionMode((scalaJSLinkerConfig in stage).value.semantics.productionMode)
+      val devServerPort = webpackDevServerPort.value
 
       val cachedActionFunction =
         FileFunction.cached(
@@ -49,6 +50,7 @@ object WebpackTasks {
             extraArgs,
             nodeArgs,
             webpackMode,
+            devServerPort,
             log
           ).cached
         }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/custom-test-config/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/custom-test-config/build.sbt
@@ -27,8 +27,6 @@ webpackBundlingMode := BundlingMode.LibraryAndApplication()
 
 useYarn := true
 
-version in webpack := "4.32.2"
-
 npmDependencies in Compile ++= Seq(
   "react"     -> reactJS,
   "react-dom" -> reactJS

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/build.sbt
@@ -9,13 +9,13 @@ scalaJSUseMainModuleInitializer := true
 
 //#relevant-settings
 npmDependencies in Compile ++= Seq(
-  "moment" -> "2.18.1"
+  "moment" -> "2.29.1"
 )
 
 npmDevDependencies in Compile ++= Seq(
-  "webpack-merge" -> "4.1.2",
-  "imports-loader" -> "0.8.0",
-  "expose-loader" -> "0.7.5"
+  "webpack-merge" -> "5.7.3",
+  "imports-loader" -> "2.0.0",
+  "expose-loader" -> "2.0.0"
 )
 
 webpackConfigFile in fastOptJS := Some(baseDirectory.value / "dev.webpack.config.js")

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/common.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/common.webpack.config.js
@@ -6,19 +6,27 @@ const importRule = {
   // Force require global modules
   test: /.*-(fast|full)opt\.js$/,
   loader:
-    "imports-loader?" +
-    Object.keys(globalModules)
+    "imports-loader",
+  options: {
+    type: 'commonjs',
+    imports: Object.keys(globalModules)
       .map(function(modName) {
-        return modName + "=" + globalModules[modName];
+        return {
+          moduleName: globalModules[modName],
+          name: modName,
+        }
       })
-      .join(",")
+  }
 };
 
 const exposeRules = Object.keys(globalModules).map(function(modName) {
   // Expose global modules
   return {
     test: require.resolve(modName),
-    loader: "expose-loader?" + globalModules[modName]
+    loader: "expose-loader",
+    options: {
+      exposes: [globalModules[modName]],
+    },
   };
 });
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/dev.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/dev.webpack.config.js
@@ -1,4 +1,4 @@
-var merge = require('webpack-merge');
+var { merge } = require('webpack-merge');
 
 var commonConfig = require('./common.webpack.config');
 var generatedConfig = require('./scalajs.webpack.config');

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/test.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/global-namespace-with-jsdom-unit-testing/test.webpack.config.js
@@ -1,5 +1,5 @@
-  var merge = require('webpack-merge');
+var { merge } = require('webpack-merge');
 
-  var commonConfig = require('./common.webpack.config');
+var commonConfig = require('./common.webpack.config');
 
-  module.exports = merge(commonConfig, {});
+module.exports = merge(commonConfig, {});

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/library/project/plugins.sbt
@@ -5,6 +5,6 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % scalaJSBundlerVersion)
 
-libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.23"
+libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.46.0"
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/build.sbt
@@ -11,17 +11,13 @@ libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.0.0"
 
 npmDependencies in Compile += "leaflet" -> "0.7.7"
 
-version in webpack                     := "4.1.1"
-
-version in startWebpackDevServer       := "3.1.1"
-
 npmDevDependencies in Compile ++= Seq(
   "webpack-merge" -> "4.1.2",
-  "file-loader" -> "1.1.11",
-  "image-webpack-loader" -> "4.1.0",
-  "css-loader" -> "0.28.10",
-  "style-loader" -> "0.20.2",
-  "url-loader" -> "1.0.1"
+  "file-loader" -> "6.2.0",
+  "image-webpack-loader" -> "7.0.1",
+  "css-loader" -> "5.0.1",
+  "style-loader" -> "2.0.0",
+  "url-loader" -> "4.1.0"
 )
 
 webpackConfigFile in fastOptJS := Some(baseDirectory.value / "dev.webpack.config.js")

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/common.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/common.webpack.config.js
@@ -43,8 +43,5 @@ module.exports = {
         }
       }
     ]
-  },
-  node: {
-    fs: "empty"
   }
 };

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/prod.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/prod.webpack.config.js
@@ -1,14 +1,6 @@
-var webpack = require("webpack");
 var merge = require("webpack-merge");
 
 var generatedConfig = require("./scalajs.webpack.config");
 var commonConfig = require("./common.webpack.config.js");
-var UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
-module.exports = merge(generatedConfig, commonConfig, {
-  plugins: [
-    new UglifyJsPlugin({
-      sourceMap: true
-    })
-  ]
-});
+module.exports = merge(generatedConfig, commonConfig);

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/sharedconfig/project/plugins.sbt
@@ -5,6 +5,6 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % scalaJSBundlerVersion)
 
-libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.23"
+libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.46.0"
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/README.md
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/README.md
@@ -5,5 +5,4 @@ An application that uses npm packages and that produces
 a static HTML page.
 
 Demonstrates how to:
-- depend on npm packages ;
-- differentiate prod/dev builds.
+- depend on npm packages.

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/build.sbt
@@ -10,11 +10,6 @@ libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.0.0"
 
 npmDependencies in Compile += "snabbdom" -> "0.5.3"
 
-npmDevDependencies in Compile += "uglifyjs-webpack-plugin" -> "1.2.2"
-
-// Use a different Webpack configuration file for production
-webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.webpack.config.js")
-
 // Execute the tests in browser-like environment
 requireJsDomEnv in Test := true
 

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/prod.webpack.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/prod.webpack.config.js
@@ -1,7 +1,0 @@
-var UglifyJsPlugin = require("uglifyjs-webpack-plugin");
-
-module.exports = require("./scalajs.webpack.config");
-
-module.exports.plugins = (module.exports.plugins || []).concat([
-  new UglifyJsPlugin({ sourceMap: module.exports.devtool === "source-map" })
-]);

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/static/project/plugins.sbt
@@ -5,6 +5,6 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % scalaJSBundlerVersion)
 
-libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.23"
+libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.46.0"
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets-cookbook/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets-cookbook/build.sbt
@@ -52,7 +52,6 @@ TaskKey[Unit]("checkArchive") := {
     "assets/webpack-assets-opt-bundle.js",
     "assets/webpack-assets-opt-loader.js",
     "assets/webpack-assets-opt-library.js",
-    "assets/webpack-assets-opt-library.js.map",
     "assets/webpack-assets-opt.js",
     "assets/react.production.min.js",
     "assets/react-dom.production.min.js"

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/badconfig1.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/badconfig1.js
@@ -1,11 +1,10 @@
 const ScalaJS = require("./scalajs.webpack.config");
-const Merge = require("webpack-merge");
+const { merge } = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 // LessLoader is requested but it is missing from npmDevDependencies
 const LessLoaderPlugin = require("less-loader");
 
-const WebApp = Merge(ScalaJS, {
-  mode: "development",
+const WebApp = merge(ScalaJS, {
   output: {
     filename: "library.js"
   },

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/badconfig2.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/badconfig2.js
@@ -1,12 +1,11 @@
 const ScalaJS = require("./scalajs.webpack.config");
-const Merge = require("webpack-merge");
+const { merge } = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const path = require("path");
 const rootDir = path.resolve(__dirname, "../../../..");
 const resourcesDir = path.resolve(rootDir, "src/main/resources");
 
-const WebApp = Merge(ScalaJS, {
-  mode: "development",
+const WebApp = merge(ScalaJS, {
   entry: {
     app: [path.resolve(resourcesDir, "./entry.js")]
   },

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/build.sbt
@@ -19,23 +19,19 @@ webpackBundlingMode in fullOptJS := BundlingMode.Application
 
 webpackConfigFile in fullOptJS := Some(baseDirectory.value / "prod.config.js")
 
-npmDevDependencies in Compile += "html-webpack-plugin" -> "4.3.0"
+npmDevDependencies in Compile += "html-webpack-plugin" -> "5.2.0"
 
-npmDevDependencies in Compile += "webpack-merge" -> "4.2.2"
+npmDevDependencies in Compile += "webpack-merge" -> "5.7.3"
 
-npmDevDependencies in Compile += "style-loader" -> "1.2.1"
+npmDevDependencies in Compile += "style-loader" -> "2.0.0"
 
-npmDevDependencies in Compile += "css-loader" -> "3.5.3"
+npmDevDependencies in Compile += "css-loader" -> "5.0.1"
 
-npmDevDependencies in Compile += "mini-css-extract-plugin" -> "0.9.0"
+npmDevDependencies in Compile += "mini-css-extract-plugin" -> "1.3.4"
 
 webpackDevServerPort := 7357
 
 useYarn := true
-
-version in webpack                     := "4.43.0"
-
-version in startWebpackDevServer       := "3.11.0"
 
 // HtmlUnit does not support ECMAScript 2015
 scalaJSLinkerConfig ~= { _.withESFeatures(_.withUseECMAScript2015(false)) }
@@ -51,10 +47,14 @@ InputKey[Unit]("html") := {
   assert(files.length == assetsCount)
   // Check all files are present
   assert(files.map(_.data.exists).forall(_ == true))
+  // There is only one app file
+  assert(files.count(_.metadata.get(BundlerFileTypeAttr) == Some(BundlerFileType.Application)) == 1)
   // There is only one library file
   assert(files.count(_.metadata.get(BundlerFileTypeAttr) == Some(BundlerFileType.Library)) == 1)
-  // And 2 assets, the css and its map
-  assert(files.count(_.metadata.get(BundlerFileTypeAttr) == Some(BundlerFileType.Asset)) == 2)
+  // There is only one library file
+  assert(files.count(_.metadata.get(BundlerFileTypeAttr) == Some(BundlerFileType.Loader)) == 1)
+  // And 1 asset (HTML file)
+  assert(files.count(_.metadata.get(BundlerFileTypeAttr) == Some(BundlerFileType.Asset)) == 1)
   // The application is the first
   assert(files.head.metadata.get(BundlerFileTypeAttr) == Some(BundlerFileType.Application))
   val client = new WebClient()

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/dev.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/dev.config.js
@@ -1,9 +1,8 @@
 const ScalaJS = require("./scalajs.webpack.config");
-const Merge = require("webpack-merge");
+const { merge } = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
-const WebApp = Merge(ScalaJS, {
-  mode: "development",
+const WebApp = merge(ScalaJS, {
   output: {
     filename: "library.js"
   },

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/prod.config.js
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/prod.config.js
@@ -1,5 +1,5 @@
 const ScalaJS = require("./scalajs.webpack.config");
-const Merge = require("webpack-merge");
+const { merge } = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
@@ -7,8 +7,7 @@ const path = require("path");
 const rootDir = path.resolve(__dirname, "../../../..");
 const resourcesDir = path.resolve(rootDir, "src/main/resources");
 
-const WebApp = Merge(ScalaJS, {
-  mode: "production",
+const WebApp = merge(ScalaJS, {
   entry: {
     app: [path.resolve(resourcesDir, "./entry.js")]
   },
@@ -16,7 +15,7 @@ const WebApp = Merge(ScalaJS, {
     rules: [
       {
         test: /\.css$/,
-        use: ["style-loader", MiniCssExtractPlugin.loader, "css-loader"]
+        use: [MiniCssExtractPlugin.loader, "css-loader"]
       }
     ]
   },

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/project/plugins.sbt
@@ -5,6 +5,6 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % scalaJSBundlerVersion)
 
-libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.40.0"
+libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.46.0"
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-assets/test
@@ -1,12 +1,12 @@
 # the server should properly start
 > fastOptJS::webpack
-# 3 assets and 2 for loader and entry
-> html index.html 5
+# 1 assets and 3 for library, loader and app
+> html index.html 4
 > clean
 
 # Now let's try optimized
 > fullOptJS::webpack
-> htmlProd index.html demo 7
+> htmlProd index.html demo 4
 
 # Error case 1
 > set webpackConfigFile in fastOptJS := Some(new File("badconfig1.js"))

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/build.sbt
@@ -12,11 +12,9 @@ scalaJSUseMainModuleInitializer := true
 // Use a custom config file
 webpackConfigFile := Some(baseDirectory.value / "webpack.config.js")
 
-(npmDevDependencies in Compile) += ("html-webpack-plugin" -> "4.3.0")
+(npmDevDependencies in Compile) += ("html-webpack-plugin" -> "5.2.0")
 
 webpackDevServerPort := 7357
-
-version in webpack                     := "4.32.2"
 
 // HtmlUnit does not support ECMAScript 2015
 scalaJSLinkerConfig ~= { _.withESFeatures(_.withUseECMAScript2015(false)) }

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/project/plugins.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/project/plugins.sbt
@@ -5,6 +5,6 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % scalaJSBundlerVersion)
 
-libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.40.0"
+libraryDependencies += "net.sourceforge.htmlunit" % "htmlunit" % "2.46.0"
 
 ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet


### PR DESCRIPTION
- Add support for Webpack 5 and drop previous versions (removing up to Webpack 4 was discussed in https://github.com/scalacenter/scalajs-bundler/issues/350, it allows to focus time on Webpack 5 only, especially as `webpack-dev-server` invocation changed as well as the output format for errors and warnings)
- Size from assets are displayed in a human format (similar to webpack, like `345,12 Kib` instead of `345127`)
- Remove `Built at` log line from stats, as in Webpack 5 (sbt is already outputting a similar line after each task).
-  As `webpack-dev-server` invocation changed, the server port is not part of the command line but it is injected in the generated webpack configuration (might be a breaking for some users).
- Remove `--bail` flag when invoking `webpack` as it does not return a JSON but print the error in `stderr` directly (parsing is failing because of that)
- Bump `net.sourceforge.htmlunit` in test to support JS from Webpack 5. Bump some npm dependencies in test to support Webpack 5.
- Remove Uglify from test as code is now automatically minified in production mode, and this plugin is not compatible with Webpack 5.

Currently I am able to use this version to compile a small application using webpack 5 (including `webpack-dev-server`).

Remaining tasks for future 🚧:
- [x] Fix test;
- [x] Errors & Warnings are not correctly parsed;
- [ ] Include related assets;
- [ ] Write unit tests for config. generation (code has been moved in side-effect free functions)
- [ ] Update documentation
  - [ ] https://scalacenter.github.io/scalajs-bundler/cookbook.html#how-to-use-webpack-4

#### Links
- [Official migration documentation](https://webpack.js.org/migrate/5/) (from 4 to 5).

#### Raw Webpack outputs
<details>
  <summary>Webpack 5 (development)</summary>
  
```
asset myapp-fastopt.js 1.34 MiB [emitted] (name: myapp-fastopt)
asset index.html 1.72 KiB [emitted]
asset icon-32.svg 180 bytes [emitted] [from: assets/icon-32.svg]
./myapp-fastopt.js 1.31 MiB [built] [code generated]
webpack 5.12.0 compiled successfully in 544 ms
```
</details>

<details>
  <summary>Webpack 5 (production)</summary>
  
```
asset myapp-opt-fe44374c39438c893626.js 258 KiB [emitted] [immutable] [minimized] (name: myapp-opt)
asset index.html 1.63 KiB [emitted]
asset icon-32-51fa7e7e665ad3b294fe37c44f732d62.svg 180 bytes [emitted] [immutable] [from: assets/icon-32.svg]
./myapp-opt.js 260 KiB [built] [code generated]
webpack 5.12.0 compiled successfully in 3547 ms
```
</details>

<details>
  <summary>Webpack 4 (development)</summary>
  
```
Hash: 3d2baa6a7539e076a4f3
Version: webpack 4.44.2
Time: 482ms
Built at: 01/09/2021 9:50:03 PM
            Asset       Size          Chunks             Chunk Names
      icon-32.svg  180 bytes                  [emitted]
       index.html   1.72 KiB                  [emitted]
myapp-fastopt.js   1.34 MiB  myapp-fastopt  [emitted]  myapp-fastopt
Entrypoint myapp-fastopt = myapp-fastopt.js
[0] multi ./myapp-fastopt.js 28 bytes {myapp-fastopt} [built]
[./myapp-fastopt.js] 1.31 MiB {myapp-fastopt} [built]
Child HtmlWebpackCompiler:
          Asset       Size  Chunks             Chunk Names
    icon-32.svg  180 bytes          [emitted]
     + 1 hidden asset
    Entrypoint HtmlWebpackPlugin_0 = __child-HtmlWebpackPlugin_0
    [./assets/icon-32.svg] 55 bytes {HtmlWebpackPlugin_0} [built]
    [./node_modules/html-webpack-plugin/lib/loader.js!./assets/index.ejs] 2.04 KiB {HtmlWebpackPlugin_0} [built]
```
</details>

<details>
  <summary>Webpack 4 (production)</summary>
  
```
Hash: d5a693b21ce4f40515c4
Version: webpack 4.44.2
Time: 391ms
Built at: 01/09/2021 9:50:50 AM
                                       Asset       Size  Chunks                         Chunk Names
icon-32-51fa7e7e665ad3b294fe37c44f732d62.svg  180 bytes          [emitted] [immutable]
                                  index.html   1.76 KiB          [emitted]
          myapp-opt-350577d29ed7f637efda.js    259 KiB       0  [emitted] [immutable]  myapp-opt
Entrypoint myapp-opt = myapp-opt-350577d29ed7f637efda.js
[0] multi ./myapp-opt.js 28 bytes {0} [built]
[1] ./myapp-opt.js 260 KiB {0} [built]
Child HtmlWebpackCompiler:
                                           Asset       Size  Chunks                         Chunk Names
    icon-32-51fa7e7e665ad3b294fe37c44f732d62.svg  180 bytes          [emitted] [immutable]
     + 1 hidden asset
    Entrypoint HtmlWebpackPlugin_0 = __child-HtmlWebpackPlugin_0
    [0] ./assets/icon-32.svg 88 bytes {0} [built]
    [1] ./node_modules/html-webpack-plugin/lib/loader.js!./assets/index.ejs 2.04 KiB {0} [built]

```
</details>

#### Raw warnings
<details>
  <summary>Webpack 5</summary>
  
```
WARNING in ./app-fastopt.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/lihaoyi/Github/scalatags/scalatags/src/scalatags/text/Builder.scala' file: Error: ENOENT: no such file or directory, open '/Users/lihaoyi/Github/scalatags/scalatags/src/scalatags/text/Builder.scala'

WARNING in ./app-fastopt.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/lihaoyi/Github/sourcecode/sourcecode/src/sourcecode/SourceContext.scala' file: Error: ENOENT: no such file or directory, open '/Users/lihaoyi/Github/sourcecode/sourcecode/src/sourcecode/SourceContext.scala'

WARNING in ./app-fastopt.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map: 'https://raw.githubusercontent.com/scala-js/scala-js-dom/v1.1.0/src/main/scala/org/scalajs/dom/package.scala' URL is not supported

WARNING in ./app-fastopt.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map: 'https://raw.githubusercontent.com/scala-js/scala-js/v1.4.0/javalanglib/src/main/scala/java/lang/Boolean.scala' URL is not supported
```
</details>

<details>
  <summary>Webpack 5</summary>
  
```
WARNING in ./app-fastopt.js
Module Warning (from ./node_modules/source-map-loader/index.js):
(Emitted value instead of an instance of Error) Cannot find source file '../../../../../../../../../lihaoyi/Github/scalatags/scalatags/src/scalatags/text/Builder.scala': Error: Can't resolve '../../../../../../../../../lihaoyi/Github/scalatags/scalatags/src/scalatags/text/Builder.scala' in '/Users/vhiairrassary/Code/test/test/app/target/scala-2.13/scalajs-bundler/main'
 @ multi ./app-fastopt.js app-fastopt[0]

WARNING in ./app-fastopt.js
Module Warning (from ./node_modules/source-map-loader/index.js):
(Emitted value instead of an instance of Error) Cannot find source file '../../../../../../../../../lihaoyi/Github/sourcecode/sourcecode/src/sourcecode/SourceContext.scala': Error: Can't resolve '../../../../../../../../../lihaoyi/Github/sourcecode/sourcecode/src/sourcecode/SourceContext.scala' in '/Users/vhiairrassary/Code/test/test/app/target/scala-2.13/scalajs-bundler/main'
 @ multi ./app-fastopt.js app-fastopt[0]

WARNING in ./app-fastopt.js
Module Warning (from ./node_modules/source-map-loader/index.js):
(Emitted value instead of an instance of Error) Cannot find source file 'https://raw.githubusercontent.com/scala-js/scala-js-dom/v1.1.0/src/main/scala/org/scalajs/dom/package.scala': Error: Can't resolve './https://raw.githubusercontent.com/scala-js/scala-js-dom/v1.1.0/src/main/scala/org/scalajs/dom/package.scala' in '/Users/vhiairrassary/Code/test/test/app/target/scala-2.13/scalajs-bundler/main'
 @ multi ./app-fastopt.js app-fastopt[0]

WARNING in ./app-fastopt.js
Module Warning (from ./node_modules/source-map-loader/index.js):
(Emitted value instead of an instance of Error) Cannot find source file 'https://raw.githubusercontent.com/scala-js/scala-js/v1.4.0/javalanglib/src/main/scala/java/lang/Boolean.scala': Error: Can't resolve './https://raw.githubusercontent.com/scala-js/scala-js/v1.4.0/javalanglib/src/main/scala/java/lang/Boolean.scala' in '/Users/vhiairrassary/Code/test/test/app/target/scala-2.13/scalajs-bundler/main'
 @ multi ./app-fastopt.js app-fastopt[0]
```
</details>