### PR TITLE
Fix webpack-dev-server logs with sbt 1.4.x

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/WebpackDevServer.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/WebpackDevServer.scala
@@ -16,13 +16,15 @@ private [scalajsbundler] class WebpackDevServer {
     * @param port - port, on which the server will operate.
     * @param extraArgs - additional arguments for webpack-dev-server.
     * @param logger - a logger to use for output
+    * @param globalLogger - a global logger to use for output even when the task is terminated
     */
   def start(
     workDir: File,
     configPath: File,
     port: Int,
     extraArgs: Seq[String],
-    logger: Logger
+    logger: Logger,
+    globalLogger: Logger,
   ) = this.synchronized {
     stop()
     worker = Some(new Worker(
@@ -30,7 +32,8 @@ private [scalajsbundler] class WebpackDevServer {
       configPath,
       port,
       extraArgs,
-      logger
+      logger,
+      globalLogger
     ))
   }
 
@@ -46,7 +49,8 @@ private [scalajsbundler] class WebpackDevServer {
     configPath: File,
     port: Int,
     extraArgs: Seq[String],
-    logger: Logger
+    logger: Logger,
+    globalLogger: Logger,
   ) {
     logger.info("Starting webpack-dev-server");
 
@@ -59,7 +63,7 @@ private [scalajsbundler] class WebpackDevServer {
       port.toString
     ) ++ extraArgs
 
-    val process = util.Commands.start(command, workDir, logger)
+    val process = util.Commands.start(command, workDir, globalLogger)
 
     def stop() = {
       logger.info("Stopping webpack-dev-server");

--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -782,13 +782,15 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
         // Server instance is project-level
         val server = webpackDevServer.value
         val logger = (streams in stageTask).value.log
+        val globalLogger = state.value.globalLogging.full
 
         server.start(
           workDir,
           config,
           port,
           extraArgs,
-          logger
+          logger,
+          globalLogger
         )
       }.dependsOn(
         // We need to execute the full webpack task once, since it generates


### PR DESCRIPTION
Fixes https://github.com/scalacenter/scalajs-bundler/issues/389

Starting with sbt 1.4.x (see https://github.com/sbt/sbt/pull/5731) it is not possible to use the task logger after the task has been finished. But this is currently how we log outputs from `webpack-dev-server`.

This PR changes the logger to use the [global one](https://github.com/sbt/sbt/blob/aa91a1b304454be0d77c0128c4f1e9f0e5ad0ed8/internal/util-logging/src/main/scala/sbt/internal/util/GlobalLogging.scala#L13-L28) for this particular use case. I still be validate this is the recommended approach as there is not much documentation about it.

Manually tested with sbt `1.2.8`, `1.3.13` and `1.4.6`.