### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Continuous Integration
+
+on: push
+
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Tests
+        run: |
+          sbt test scripted


### PR DESCRIPTION
Due to the recent changes announced by [Travis CI](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing) here is a PR to add GitHub Actions to the repository.
As of today, in Travis CI, we can see the following header:
> Please be aware travis-ci.org will be shutting down in several weeks, with all accounts migrating to travis-ci.com. Please stay tuned here for more information.

For now, it could only be added to compare both outputs without being required to be ✅.
If interested, can one of the maintainer enable GitHub Actions for this repository please?