### PR TITLE
Update sbt to 1.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
         with:
           java-version: "adopt@1.11"
       - uses: coursier/cache-action@v5
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.2
+      - name: Setup yarn
+        run: npm install -g yarn@1.22.15
       - name: Unit tests
         run: sbt test
       - name: Scripted tests

--- a/build.sbt
+++ b/build.sbt
@@ -121,8 +121,8 @@ lazy val commonSettings = List(
     "-Dsbt.execute.extrachecks=true" // Avoid any deadlocks.
   ),
   scriptedBufferLog := false,
-  crossSbtVersions := List("1.2.8"),
-  sbtVersion in pluginCrossBuild := "1.2.8",
+  crossSbtVersions := List("1.6.2"),
+  sbtVersion in pluginCrossBuild := "1.6.2",
 )
 
 lazy val noPublishSettings =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.8
+sbt.version = 1.6.2

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/build.sbt
@@ -14,6 +14,8 @@ webpackConfigFile := Some(baseDirectory.value / "webpack.config.js")
 
 (npmDevDependencies in Compile) += ("html-webpack-plugin" -> "5.2.0")
 
+webpackCliVersion := "4.9.0"
+
 webpackDevServerPort := 7357
 
 // HtmlUnit does not support ECMAScript 2015

--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/yarn-interactive/build.sbt
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/yarn-interactive/build.sbt
@@ -6,7 +6,7 @@ yarnExtraArgs in Compile := Seq("--silent")
 
 scalaJSUseMainModuleInitializer := true
 
-npmDependencies in Compile += "neat" -> "1.1.2"
+npmDependencies in Compile += "neat" -> "2.1.0"
 
 enablePlugins(ScalaJSBundlerPlugin)
 


### PR DESCRIPTION
Also fixes tests and sets up Node and yarn in specific versions for CI, hopefully that is a quick fix to make tests less brittle.