### PR TITLE
Fix release version numbering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # fetches all tags, required to correctly set the version
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v12
       - uses: olafurpg/setup-gpg@v3
       - uses: coursier/cache-action@v5


### PR DESCRIPTION
`fetch-depth: 0` is required for `checkout` action to fetch tags, which are needed to correctly set versions. All releases from the workflow have been `0.0.0` so far - https://oss.sonatype.org/content/repositories/snapshots/ch/epfl/scala/scalajs-bundler-linker_2.12/.