### PR TITLE
Disable the webpack-dev-server test.

### DIFF
--- a/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/test
+++ b/sbt-scalajs-bundler/src/sbt-test/sbt-scalajs-bundler/webpack-dev-server/test
@@ -1,13 +1,17 @@
-# the server should properly start
-> fastOptJS::startWebpackDevServer
-> html index.html 20000 true
+# keep at least this test while the rest is disabled
+> fastOptJS::webpack
 
-# the server should properly stop
-> fastOptJS::stopWebpackDevServer
-> html index.html 1000 false
+# disabled because Webpack/webpack-cli/htmlunit don't want to work together anymore
+# # the server should properly start
+# > fastOptJS::startWebpackDevServer
+# > html index.html 20000 true
 
-# the server should properly terminate on exit
-> fastOptJS::startWebpackDevServer
-> html index.html 20000 true
--> exit
-> html index.html 1000 false
+# # the server should properly stop
+# > fastOptJS::stopWebpackDevServer
+# > html index.html 1000 false
+
+# # the server should properly terminate on exit
+# > fastOptJS::startWebpackDevServer
+# > html index.html 20000 true
+# -> exit
+# > html index.html 1000 false


### PR DESCRIPTION
It breaks the CI because Webpack, webpack-cli and htmlunit do not want to work together anymore.