### PR TITLE
Fixed Webpack stats parsing errors

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/Stats.scala
@@ -9,7 +9,10 @@ import java.io.File
 import java.nio.file.Path
 
 /**
- * Webpack stats model and json parsers
+ * Webpack stats model and json parsers.
+ * 
+ * See:
+ *   https://webpack.js.org/api/stats/
  */
 object Stats {
 
@@ -50,9 +53,9 @@ object Stats {
 
   }
 
-  final case class WebpackError(moduleName: String, message: String, loc: String)
+  final case class WebpackError(moduleName: Option[String], message: String, loc: Option[String])
 
-  final case class WebpackWarning(moduleName: String, message: String)
+  final case class WebpackWarning(moduleName: Option[String], message: String)
 
   final case class WebpackStats(
     version: String,
@@ -115,13 +118,13 @@ object Stats {
   )(Asset.apply _)
 
   implicit val errorReads: Reads[WebpackError] = (
-    (JsPath \ "moduleName").read[String] and
+    (JsPath \ "moduleName").readNullable[String] and
       (JsPath \ "message").read[String] and
-      (JsPath \ "loc").read[String]
+      (JsPath \ "loc").readNullable[String]
     )(WebpackError.apply _)
 
   implicit val warningReads: Reads[WebpackWarning] = (
-    (JsPath \ "moduleName").read[String] and
+    (JsPath \ "moduleName").readNullable[String] and
       (JsPath \ "message").read[String]
     )(WebpackWarning.apply _)
 


### PR DESCRIPTION
Notes:
- fixes webpack json stats parsing errors on missing optional fields in `errors`/`warnings` objects:
```
[error] Error parsing webpack stats output
[error] /warnings(0)/moduleName: JsonValidationError(List(error.path.missing),WrappedArray())
[error] /warnings(1)/moduleName: JsonValidationError(List(error.path.missing),WrappedArray())

[error] Error parsing webpack stats output
[error] /errors(0)/loc: JsonValidationError(List(error.path.missing),WrappedArray())
[error] /errors(1)/loc: JsonValidationError(List(error.path.missing),WrappedArray())
```
- in case other parsing errors occur - prints `webpack` command to run manually that will help fixing original issues