### PR TITLE
Fetch tags when deploying GH pages for dynver to display correct version

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -10,7 +10,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: "adopt@1.11"


### PR DESCRIPTION
I believe this is the reason for 
<img width="847" alt="image" src="https://user-images.githubusercontent.com/1052965/210968705-0f282116-a1f7-40ae-bb27-5298245d9b1c.png">
