### PR TITLE
Support Node.js 18 out-of-the-box

### DIFF
--- a/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
+++ b/sbt-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/ScalaJSBundlerPlugin.scala
@@ -553,7 +553,7 @@ object ScalaJSBundlerPlugin extends AutoPlugin {
 
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
 
-    version in webpack := "5.24.3",
+    version in webpack := "5.75.0",
 
     webpackCliVersion := "4.5.0",
 


### PR DESCRIPTION
Currently when Node.js 18 is used with `scalajs-bundler`, webpack will throw an `ERR_OSSL_EVP_UNSUPPORTED` error as described in https://github.com/webpack/webpack/issues/14532

This PR upgrades webpack to 5.75.0, which includes the fix to `ERR_OSSL_EVP_UNSUPPORTED`.

This PR fixes #438.