### PR TITLE
Use fastLinkJS / fullLinkJS

### DIFF
--- a/sbt-web-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebScalaJSBundlerPlugin.scala
+++ b/sbt-web-scalajs-bundler/src/main/scala/scalajsbundler/sbtplugin/WebScalaJSBundlerPlugin.scala
@@ -70,8 +70,8 @@ object WebScalaJSBundlerPlugin extends AutoPlugin {
             .map { project =>
               Def.settingDyn {
                 val sjsStage = (scalaJSStage in project).value match {
-                  case Stage.FastOpt => fastOptJS
-                  case Stage.FullOpt => fullOptJS
+                  case Stage.FastOpt => fastLinkJS
+                  case Stage.FullOpt => fullLinkJS
                 }
                 Def.task {
                   val files = (webpack in (project, Compile, sjsStage)).value


### PR DESCRIPTION
A simple replacement yields error in my project, not sure why though. Opening this as start of a discussion.

```
[error] Runtime references to undefined settings: 
[error] 
[error]   client / Compile / fastLinkJS / finallyEmitSourceMaps from server / scalaJSPipeline ((scalajsbundler.sbtplugin.WebScalaJSBundlerPlugin.projectSettings) WebScalaJSBundlerPlugin.scala:48)
[error] 
[error]   client / Compile / fastLinkJS / webpack from server / scalaJSPipeline ((scalajsbundler.sbtplugin.WebScalaJSBundlerPlugin.projectSettings) WebScalaJSBundlerPlugin.scala:48)
[error]
```

I'd like to switch to fastLinkJS to use the new dynamic module loading, but keep scalajs-web-bundler to package my assets into the server :)